### PR TITLE
Standardise criterion reports label

### DIFF
--- a/docs/lag-complexity-function-design.md
+++ b/docs/lag-complexity-function-design.md
@@ -970,7 +970,7 @@ from parallelism.
 Transparent and reproducible performance reporting is crucial for users and
 maintainers.
 
-- **Criterion reports:** The `criterion` framework automatically generates
+- **`criterion` reports:** The `criterion` framework automatically generates
   detailed HTML reports with statistical analysis of benchmark runs, which can
   be archived for historical comparison.
 - **Version-Controlled Summary:** A `BENCHMARKS.md` file will be maintained in


### PR DESCRIPTION
## Summary
- align criterion benchmark report bullet with heading-cased bold prefix
- ensure phrasing consistency in reporting section

closes #5

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_68a2d4a4941c832286c7244e4351f99f

## Summary by Sourcery

Documentation:
- Use inline code formatting and heading-case for the 'criterion reports' bullet in the complexity design docs