### PR TITLE
Standardise `rayon` speed-up subheading

### DIFF
--- a/docs/lag-complexity-function-design.md
+++ b/docs/lag-complexity-function-design.md
@@ -960,10 +960,10 @@ A key advantage of the Rust implementation is its ability to leverage
 multi-core processors. These benchmarks will quantify the performance gains
 from parallelism.
 
-- **Rayon speed-up:** Benchmark `score_batch` with the `rayon` feature enabled,
-  running on 1, 2, 4, 8, and 16 threads. The results will be used to calculate
-  the speed-up factor and assess how effectively the implementation scales with
-  additional CPU cores.
+- **`rayon` speed-up:** The `score_batch` method will be benchmarked with the
+  `rayon` feature enabled, running on 1, 2, 4, 8, and 16 threads. The results
+  will be used to calculate the speed-up factor and assess how effectively the
+  implementation scales with additional CPU cores.
 
 ### Reporting
 


### PR DESCRIPTION
## Summary
- emphasise `rayon` feature in speed-up subheading for consistent documentation style

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`

closes #4

------
https://chatgpt.com/codex/tasks/task_e_68a2d4e4286883229ecdb1c5b5ccbdd8

## Summary by Sourcery

Update documentation to standardise the formatting of the rayon speed-up subheading and improve the phrasing of the benchmarking description for consistency.

Documentation:
- Apply inline code formatting to the `rayon` label in the speed-up subheading
- Revise the benchmarking sentence to describe the `score_batch` method in a consistent manner