### PR TITLE
docs: tidy design doc headings and spelling

### DIFF
--- a/docs/lag-complexity-function-design.md
+++ b/docs/lag-complexity-function-design.md
@@ -333,7 +333,7 @@ up API keys. This combination creates a secure-by-default yet
 powerful-out-of-the-box library that serves the needs of most users while
 guiding them toward safe and efficient deployment patterns.
 
-#### Table 1: Feature flag specification
+#### Table 1: feature flag specification
 
 | Feature Flag      | Dependencies                                      | Purpose                                                                               | Default |
 | ----------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------- | ------- |
@@ -538,7 +538,7 @@ local provider, ensuring service continuity. This flexibility in managing the
 trade-offs between accuracy, latency, and cost is a hallmark of a
 production-oriented, industrial-grade system.
 
-#### Table 2: Provider implementation trade-offs (depth & ambiguity)
+#### Table 2: provider implementation trade-offs (depth & ambiguity)
 
 | Provider Type       | Accuracy | Latency         | Cost (Compute/API) | Dependencies                | Use Case                                                             |
 | ------------------- | -------- | --------------- | ------------------ | --------------------------- | -------------------------------------------------------------------- |

--- a/docs/lag-complexity-function-design.md
+++ b/docs/lag-complexity-function-design.md
@@ -1,4 +1,4 @@
-# Design Proposal for the ,`lag_complexity`, Crate: A Production-Ready Implementation of the LAG Cognitive Load Metric
+# Design proposal for the `lag_complexity` crate: a production-ready implementation of the LAG cognitive load metric
 
 ## Introduction: Bridging Principled Reasoning and Production Systems
 
@@ -21,7 +21,7 @@ errors through the reasoning chain.4
 
 The Logic-Augmented Generation (LAG) paradigm offers a principled alternative
 to address these shortcomings.3 Inspired by Cartesian principles of methodical
-problem-solving, LAG introduces a "reasoning-first" pipeline that prioritizes
+problem-solving, LAG introduces a "reasoning-first" pipeline that prioritises
 systematic question decomposition and dependency-aware resolution over
 immediate, brute-force retrieval.4 This approach represents a significant
 architectural shift, moving from purely semantic pattern matching toward a more
@@ -81,7 +81,7 @@ frameworks like Cognitive Architectures for Language Agents (CoALA), which
 advocate for distinct, interoperable components for memory, action, and
 decision-making.8 By isolating the complexity scoring logic, several
 engineering advantages are unlocked. The component can be independently
-benchmarked and optimized for performance, a critical requirement for a
+benchmarked and optimised for performance, a critical requirement for a
 function that may be on the hot path of every incoming query. Its internal
 implementations—the providers for each complexity signal—can be swapped out or
 upgraded without impacting the core logic of the consuming agent. This
@@ -98,13 +98,13 @@ scalability of the entire AI ecosystem it serves.
 The architecture of the `lag_complexity` crate is designed for modularity,
 performance, and ergonomic use. It provides a clear separation of concerns
 between the high-level API, the pluggable component providers, and the
-configuration, enabling developers to easily integrate and customize the
+configuration, enabling developers to easily integrate and customise the
 complexity scoring logic.
 
 ### Module Structure and Naming Conventions
 
 The crate will follow standard Rust conventions, with a logical internal module
-structure to organize its components. All primary public-facing types will be
+structure to organise its components. All primary public-facing types will be
 re-exported at the crate root for convenient access.
 
 - `lag_complexity::api`: Contains the core public traits (`ComplexityFn`) and
@@ -317,7 +317,7 @@ Cargo's feature flag system will be used extensively to manage optional
 dependencies and conditional compilation, creating a highly flexible and lean
 library.
 
-The selection of default features is a deliberate design choice prioritizing
+The selection of default features is a deliberate design choice prioritising
 security and ease of use. By disabling `provider-api` by default, the crate
 adheres to the principle of least privilege, preventing any unintended network
 activity unless explicitly opted into by the developer.17 This is a critical
@@ -353,20 +353,20 @@ the three core signals—Semantic Scope, Reasoning Steps, and Ambiguity. This
 tiered approach allows users to select the optimal trade-off between accuracy,
 latency, and computational cost for their specific application.
 
-### 2.1 Semantic Scope: ,`σ(Var(ϕ(q)))`
+### 2.1 Semantic scope: σ(Var(ϕ(q)))
 
 The Semantic Scope component measures the conceptual breadth of a query. A high
 scope suggests the query touches on multiple, disparate topics, which may
 require a wider retrieval strategy.
 
-#### Default Implementation (,`ScopeVariance`,)
+#### Default implementation (ScopeVariance)
 
 - **Formulaic Fidelity:** The default implementation will adhere precisely to
   the definition provided in the LAG paper: the variance across the dimensions
   of the query's embedding vector, `ϕ(q)`.6 The mathematical formula is
   `Var(v) = (1/d) * Σ_{i=1..d} (v_i − mean(v))^2`.
 
-  ```text
+  ```plaintext
   Var(v) = (1/d) * Σ_{i=1..d} (v_i − mean(v))^2
   ```
 
@@ -412,13 +412,13 @@ local options.
   like `all-MiniLM-L6-v2`. Clear instructions will be provided for downloading
   model weights and configuring the provider to use them.
 
-### 2.2 Reasoning Steps: ,`σ(Depth(q))`
+### 2.2 Reasoning steps: σ(Depth(q))
 
 This component estimates the number of latent inference steps required to
 answer a query. A high depth score is the primary trigger for query
 decomposition in a LAG system.
 
-#### Heuristic Baseline (,`DepthHeuristic`,)
+#### Heuristic baseline (DepthHeuristic)
 
 This implementation provides a very fast, dependency-free baseline for
 estimating reasoning depth. While not as accurate as a model-based approach, it
@@ -435,12 +435,12 @@ and logical complexity.22
 - **Comparative Structures:** It will detect phrases indicative of comparison,
   such as "compared to," "versus," "as opposed to," and the use of comparative
   adjectives ("more than," "less than").
-- **Dependency Chains:** It will penalize sequences of prepositional phrases,
+- **Dependency Chains:** It will penalise sequences of prepositional phrases,
   particularly possessive chains (e.g., "the name of the director of the sequel
   to the movie..."), which often signal nested entity relationships.
 - **Relative Clauses:** It will increment the score for clauses introduced by
   relative pronouns like "who," "which," "that," and "whose."
-- **Enumerations:** It will recognize explicit lists and enumerations (e.g.,
+- **Enumerations:** It will recognise explicit lists and enumerations (e.g.,
   "What are the differences between A, B, and C?").
 - **Aggregation:** The final heuristic score will be a weighted sum of the
   counts of these features. The weights will be empirically tuned against a
@@ -471,19 +471,19 @@ For higher accuracy, the crate will provide model-based estimators.
   LLM to explicitly break down the question and count the sub-questions. For
   example:
 
-  ```text
+  ```plaintext
   Prompt: Analyse the question "Which university did the CEO of the company that developed the original iPhone attend?" and
   state the number of reasoning steps required.
   Response: 2
   ```
 
-### 2.3 Ambiguity: ,`σ(H(q))`
+### 2.3 Ambiguity: σ(H(q))
 
 This component quantifies the semantic uncertainty in a query. A high ambiguity
 score suggests the query may have multiple valid interpretations and should be
 clarified before attempting to answer.
 
-#### Heuristic Baseline (,`AmbiguityHeuristic`,)
+#### Heuristic baseline (AmbiguityHeuristic)
 
 This provides a fast, lightweight signal for common sources of ambiguity in
 English text.25
@@ -501,14 +501,14 @@ English text.25
   ambiguous entities (e.g., "Mercury": planet, god, element, car brand; "Nile":
   river, band). An NER pre-pass (even a simple regex-based one) will identify
   these terms and increment the score.
-- **Ellipsis and Vagueness:** The score will be penalized for vague quantifiers
+- **Ellipsis and Vagueness:** The score will be penalised for vague quantifiers
   ("some," "a few," "several") and deictic terms ("here," "there," "then") that
   lack a concrete anchor in the query's context.
 - **Aggregation:** The scores from these risk factors will be combined into a
   single pseudo-entropy value. Laplace smoothing will be applied to ensure a
   stable, non-zero score even for queries with no detected ambiguity signals.
 
-#### Model-Backed Option (,`AmbiguityClassifierOnnx`,)
+#### Model-backed option (AmbiguityClassifierOnnx)
 
 - Enabled by the `onnx` feature, this provider uses a lightweight text
   classification model for more nuanced ambiguity detection.
@@ -583,12 +583,12 @@ range, typically [0, 1], so they can be meaningfully aggregated into the final
   effectiveness depends entirely on being calibrated against a dataset of
   queries that is representative of the target domain. The crate will ship with
   a set of default parameters calibrated on a general-purpose web question
-  dataset. However, the documentation will strongly emphasize that for optimal
+  dataset. However, the documentation will strongly emphasise that for optimal
   performance, users must perform their own calibration step using
   domain-specific data and the evaluation harness provided by the crate (see
   Section 5).
 
-### Split Scheduling (,`Schedule`, and ,`τ(t)`,)
+### Split scheduling (Schedule and τ(t))
 
 This component directly implements the adaptive decomposition logic from the
 LAG paper: `SplitCondition(q) = CL(q) > τ(t)`.6 The core concept is that the
@@ -613,7 +613,7 @@ threshold for decomposition,
 - `lambda`: The decay rate, controlling how quickly the threshold decreases
   with each step.
 
-### Halting Conditions (,`Halting`,)
+### Halting conditions (Halting)
 
 The `Halting` configuration provides the parameters for the "Logical
 Terminator," a critical safety and efficiency mechanism described in the LAG
@@ -650,7 +650,7 @@ ensure the `lag_complexity` crate is robust and operationally sound.
 ### Concurrency and Parallelism
 
 Rust's fearless concurrency model is a primary reason for its selection for
-this task. The crate will leverage this capability to maximize throughput.
+this task. The crate will leverage this capability to maximise throughput.
 
 - **Batch Processing:** The `ComplexityFn` trait will expose a
   `score_batch(&self, q: &[&str]) -> Vec<Result<Complexity, Error>>` method.
@@ -796,7 +796,7 @@ in isolation.
   (e.g., "it" without a clear antecedent) or known homonyms never decreases the
   ambiguity score.
 
-### Property Tests (,`proptest`,)
+### Property tests (proptest)
 
 Property-based testing, using the `proptest` crate, will be employed to test
 for invariants that must hold true for a wide range of arbitrary, automatically
@@ -911,7 +911,7 @@ Benchmarks will reside in the `benches/` directory and can be executed via
 ### Micro-benchmarks
 
 These benchmarks will isolate and measure the performance of individual,
-critical components to identify potential bottlenecks and guide optimization
+critical components to identify potential bottlenecks and guide optimisation
 efforts.
 
 - **Provider Latency:**
@@ -1171,8 +1171,8 @@ mad = 0.1
 
 [weights]
 scope = 1.0
-depth = 1.2 # Slightly emphasize reasoning steps
-ambiguity = 1.5 # Strongly emphasize ambiguity for safety
+depth = 1.2 # Slightly emphasise reasoning steps
+ambiguity = 1.5 # Strongly emphasise ambiguity for safety
 
 [schedule]
 type = "ExpDecay"
@@ -1276,7 +1276,7 @@ relying on fast, lightweight heuristics.
 ### Phase 2 — Model-Backed Providers & Performance (Duration: 2 weeks)
 
 This phase focuses on enhancing accuracy with model-based providers and
-optimizing for performance.
+optimising for performance.
 
 - **Tasks:**
 
@@ -1350,7 +1350,7 @@ observable production deployment.
 - Implement the `with_redaction_hook` method for PII scrubbing.
 - Write comprehensive `rustdoc` documentation for all public APIs, including
   detailed usage examples.
-- Finalize the `README.md` to include installation instructions, usage
+- Finalise the `README.md` to include installation instructions, usage
   examples, and links to benchmarks and evaluation reports.
 - **Acceptance Criteria:**
 
@@ -1439,7 +1439,7 @@ control flow.
 The development of this crate is a foundational step toward building more
 sophisticated language agents that are capable of metacognition—the ability to
 reason about their own reasoning process. Frameworks for advanced AI, such as
-Cognitive Architectures for Language Agents (CoALA), emphasize the need for
+Cognitive Architectures for Language Agents (CoALA), emphasise the need for
 agents to possess distinct modules for memory, action, and deliberative
 decision-making.8 The
 

--- a/docs/lag-complexity-function-design.md
+++ b/docs/lag-complexity-function-design.md
@@ -1,8 +1,8 @@
 # Design proposal for the `lag_complexity` crate: a production-ready implementation of the LAG cognitive load metric
 
-## Introduction: Bridging Principled Reasoning and Production Systems
+## Introduction: bridging principled reasoning and production systems
 
-### Context and Motivation
+### Context and motivation
 
 Modern Large Language Models (LLMs) have demonstrated remarkable capabilities
 across a broad spectrum of natural language tasks, from text generation to
@@ -17,7 +17,7 @@ capture the underlying logical structure of complex queries, leading to the
 retrieval of fragmented or irrelevant context and subsequent propagation of
 errors through the reasoning chain.4
 
-### The LAG Paradigm
+### The LAG paradigm
 
 The Logic-Augmented Generation (LAG) paradigm offers a principled alternative
 to address these shortcomings.3 Inspired by Cartesian principles of methodical
@@ -30,7 +30,7 @@ strategies for tackling complex problems. This aligns with broader trends in AI
 toward building more sophisticated language agents that incorporate explicit
 mechanisms for planning, memory, and reasoning.8
 
-### The Role of CL(q)
+### The role of CL(q)
 
 The cornerstone of the LAG framework is its adaptive decomposition module,
 which intelligently determines _when_ a query is too complex for direct
@@ -45,7 +45,7 @@ proceed with direct generation or to initiate a recursive decomposition
 process, ensuring that each reasoning step is taken on a manageable,
 well-defined problem.
 
-### Crate Mission Statement
+### Crate mission statement
 
 This document outlines the design for the `lag_complexity` crate, a
 high-performance, modular, and production-grade Rust implementation of the
@@ -58,7 +58,7 @@ will leverage the language's strengths in performance, concurrency, and safety
 to deliver a reliable and efficient component suitable for demanding production
 environments.
 
-### Disambiguation of "Cognitive Complexity"
+### Disambiguation of "cognitive complexity"
 
 It is critical to establish a clear distinction at the outset. The cognitive
 complexity metric implemented in this crate is the _Cognitive Load_ for natural
@@ -93,7 +93,7 @@ Therefore, the creation of the
 foundational choice that enhances the testability, maintainability, and
 scalability of the entire AI ecosystem it serves.
 
-## 1. Crate Architecture and Public API
+## 1. Crate architecture and public API
 
 The architecture of the `lag_complexity` crate is designed for modularity,
 performance, and ergonomic use. It provides a clear separation of concerns
@@ -101,7 +101,7 @@ between the high-level API, the pluggable component providers, and the
 configuration, enabling developers to easily integrate and customise the
 complexity scoring logic.
 
-### Module Structure and Naming Conventions
+### Module structure and naming conventions
 
 The crate will follow standard Rust conventions, with a logical internal module
 structure to organise its components. All primary public-facing types will be
@@ -118,7 +118,7 @@ re-exported at the crate root for convenient access.
 - `lag_complexity::error`: Defines the crate's custom `Error` enum using the
   `thiserror` crate for ergonomic error handling.
 
-### Core Types Deep Dive
+### Core types deep dive
 
 The central data structures are designed for transparency and interoperability.
 
@@ -219,7 +219,7 @@ sequenceDiagram
   end
 ```
 
-### Provider Traits
+### Provider traits
 
 These traits are the key to the crate's modularity, allowing for the
 implementation of each complexity signal to be swapped at runtime or compile
@@ -311,7 +311,7 @@ pub struct Halting {
 }
 ```
 
-### Feature Flags
+### Feature flags
 
 Cargo's feature flag system will be used extensively to manage optional
 dependencies and conditional compilation, creating a highly flexible and lean
@@ -333,7 +333,7 @@ up API keys. This combination creates a secure-by-default yet
 powerful-out-of-the-box library that serves the needs of most users while
 guiding them toward safe and efficient deployment patterns.
 
-#### Table 1: Feature Flag Specification
+#### Table 1: Feature flag specification
 
 | Feature Flag      | Dependencies                                      | Purpose                                                                               | Default |
 | ----------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------- | ------- |
@@ -346,7 +346,7 @@ guiding them toward safe and efficient deployment patterns.
 | `wasm`            | `wasm-bindgen`, `js-sys`                          | Builds a WebAssembly module for browser/JS environments.                              | Off     |
 | `cli`             | `clap`                                            | Builds the `lagc` command-line interface binary.                                      | On      |
 
-## 2. Component Signal Implementations
+## 2. Component signal implementations
 
 The crate will provide multiple, interchangeable implementations for each of
 the three core signals—Semantic Scope, Reasoning Steps, and Ambiguity. This
@@ -382,7 +382,7 @@ require a wider retrieval strategy.
   such as Welford's online algorithm. This avoids the catastrophic cancellation
   that can occur with the naive two-pass formula.
 
-#### Embedding Providers
+#### Embedding providers
 
 The quality of the Semantic Scope signal is entirely dependent on the quality
 of the underlying embedding, `ϕ(q)`. The crate will provide both remote and
@@ -446,7 +446,7 @@ and logical complexity.22
   counts of these features. The weights will be empirically tuned against a
   curated set of multi-hop questions.
 
-#### Model-Backed Options
+#### Model-backed options
 
 For higher accuracy, the crate will provide model-based estimators.
 
@@ -538,7 +538,7 @@ local provider, ensuring service continuity. This flexibility in managing the
 trade-offs between accuracy, latency, and cost is a hallmark of a
 production-oriented, industrial-grade system.
 
-#### Table 2: Provider Implementation Trade-offs (Depth & Ambiguity)
+#### Table 2: Provider implementation trade-offs (depth & ambiguity)
 
 | Provider Type       | Accuracy | Latency         | Cost (Compute/API) | Dependencies                | Use Case                                                             |
 | ------------------- | -------- | --------------- | ------------------ | --------------------------- | -------------------------------------------------------------------- |
@@ -546,14 +546,14 @@ production-oriented, industrial-grade system.
 | **ONNX Classifier** | Medium   | Low (~5-20ms)   | Low (local CPU)    | `ort` crate, model file     | Production systems needing a balance of speed and accuracy.          |
 | **External LLM**    | High     | High (500ms+)   | High               | `reqwest`, `tokio`, API key | Systems where accuracy is paramount and latency/cost are acceptable. |
 
-## 3. Configuration Deep Dive: Normalisation, Scheduling, and Halting
+## 3. Configuration deep dive: normalisation, scheduling, and halting
 
 Effective configuration is central to the `lag_complexity` crate's
 adaptability. The `ScoringConfig` structure provides fine-grained control over
 how raw signals are processed and interpreted, allowing the system to be tuned
 for specific domains and performance requirements.
 
-### Normalisation (Sigma)
+### Normalisation (sigma)
 
 The raw scores produced by the various providers—embedding variance, heuristic
 counts, or model outputs—exist on different, arbitrary scales. The `Sigma`
@@ -640,14 +640,14 @@ single, coherent interface for tuning the entire cognitive control loop of a
 LAG agent, from the initial decomposition decision to the final termination
 conditions.
 
-## 4. Production Engineering and Operations
+## 4. Production engineering and operations
 
 A library intended for production use in high-performance AI systems must be
 engineered for concurrency, efficiency, observability, and security. This
 section details the non-functional requirements and design choices that will
 ensure the `lag_complexity` crate is robust and operationally sound.
 
-### Concurrency and Parallelism
+### Concurrency and parallelism
 
 Rust's fearless concurrency model is a primary reason for its selection for
 this task. The crate will leverage this capability to maximise throughput.
@@ -669,7 +669,7 @@ this task. The crate will leverage this capability to maximise throughput.
    operations (like running heuristic estimators), significantly reducing the
    end-to-end latency for a single query.
 
-### Caching Strategy
+### Caching strategy
 
 The most computationally expensive operation in the scoring pipeline is
 typically embedding generation. An effective caching strategy is therefore
@@ -694,7 +694,7 @@ which are critical for managing the cache's memory footprint and data freshness.
   key distribution and fixed key size. The cache itself will be configurable
   for maximum number of entries and an optional time-to-live (TTL) for entries.
 
-### Observability (Metrics & Tracing)
+### Observability (metrics & tracing)
 
 To operate and debug the system in production, deep visibility into its
 behaviour is required. The crate will provide first-class support for modern
@@ -762,7 +762,7 @@ deterministic for a given input and configuration.
   configuration file, ensuring that the exact parameters used for evaluation
   are captured and reproducible.
 
-## 5. Comprehensive Testing and Evaluation Strategy
+## 5. Comprehensive testing and evaluation strategy
 
 A rigorous, multi-layered testing and evaluation strategy is essential to
 validate the correctness, robustness, and effectiveness of the `lag_complexity`
@@ -771,7 +771,7 @@ for behavioural invariants, integration tests for component composition, and a
 large-scale evaluation against academic datasets to measure real-world
 performance.
 
-### Unit Tests
+### Unit tests
 
 Located directly alongside the code they test (within `#[cfg(test)]` modules),
 unit tests will verify the correctness of individual functions and components
@@ -819,7 +819,7 @@ test writers might miss.
   (e.g., "versus", "in addition to") should generally lead to a non-decreasing
   `depth` score.
 
-### Integration Tests
+### Integration tests
 
 Located in the `tests/` directory, these tests will verify that the different
 components of the crate work correctly together.
@@ -841,7 +841,7 @@ components of the crate work correctly together.
   servers like `wiremock`) and that ONNX models can be loaded and executed
   successfully.
 
-### Dataset-Driven Evaluation
+### Dataset-driven evaluation
 
 To validate that the complexity scores are not just internally consistent but
 also correlate with real-world notions of complexity, a dedicated evaluation
@@ -893,7 +893,7 @@ simpler ones.
   for each version of the crate. This provides a transparent and reproducible
   record of the scorer's empirical validity.
 
-## 6. Performance Benchmarking Protocol
+## 6. Performance benchmarking protocol
 
 To ensure the `lag_complexity` crate meets the performance requirements of
 production AI systems, a systematic benchmarking protocol will be established.
@@ -954,7 +954,7 @@ simulating real-world usage patterns.
   of providers (e.g., full heuristic, heuristic + ONNX, full API) to provide
   users with clear performance expectations for each configuration.
 
-### Scalability Benchmarks
+### Scalability benchmarks
 
 A key advantage of the Rust implementation is its ability to leverage
 multi-core processors. These benchmarks will quantify the performance gains
@@ -981,7 +981,7 @@ maintainers.
   and software (Rust version, OS, crate feature flags) configuration used for
   the benchmark run, ensuring that the results are reproducible.
 
-## 7. Stakeholder Demonstration and Application
+## 7. Stakeholder demonstration and application
 
 To effectively communicate the value and functionality of the `lag_complexity`
 crate to a broader audience, including product managers, technical leadership,
@@ -989,7 +989,7 @@ and other stakeholders, a set of clear and compelling demonstrations will be
 developed. These demonstrations will translate the abstract concept of
 "cognitive load" into tangible, intuitive examples of improved system behaviour.
 
-### Live "Complexity Meter" (WASM Demo)
+### Live "complexity meter" (WASM demo)
 
 This interactive web-based demonstration will provide an immediate, hands-on
 experience of the complexity metric in action.
@@ -1018,7 +1018,7 @@ experience of the complexity metric in action.
   stakeholders to develop an intuitive "feel" for what kinds of questions are
   considered complex by the system.
 
-### Python Notebook Walkthroughs
+### Python notebook walkthroughs
 
 For a more narrative and comparative demonstration, a series of Jupyter
 notebooks will be created. These will leverage the Python bindings generated by
@@ -1071,7 +1071,7 @@ These demonstrations, powered by the crate's `wasm` and `python` bindings, will
 provide powerful tools for communicating its value beyond the immediate
 implementation team.
 
-## 8. Reference Implementation and Usage Patterns
+## 8. Reference implementation and usage patterns
 
 To ensure developers can quickly and correctly integrate the `lag_complexity`
 crate, the documentation will include clear, practical examples of its primary
@@ -1154,7 +1154,7 @@ compilation based on the `rayon` feature flag. It walks through the logical
 flow from raw provider outputs to the final, normalised, and weighted
 `Complexity` score.
 
-### Configuration from File
+### Configuration from file
 
 To promote best practices for configuration management, an example will show
 how to deserialise the `ScoringConfig` from a TOML file. This allows for easy
@@ -1223,14 +1223,14 @@ fn print_trace(scorer: &impl ComplexityFn, query: &str) {
 This example highlights how the `Trace` object exposes the original query and
 its component scores, aiding debugging without additional instrumentation.
 
-## 9. Phased Implementation and Project Roadmap
+## 9. Phased implementation and project roadmap
 
 To ensure a structured and predictable development process, the implementation
 of the `lag_complexity` crate will be divided into five distinct phases. Each
 phase has a clear set of deliverables and acceptance criteria, allowing for
 iterative progress and early validation of the core components.
 
-### Phase 0 — Scaffolding & Core API (Duration: 1 week)
+### Phase 0 — scaffolding & core API (duration: 1 week)
 
 This foundational phase focuses on establishing the crate's architecture and
 defining the primary public interfaces.
@@ -1254,7 +1254,7 @@ defining the primary public interfaces.
 - The `lagc` CLI application can be built and executed, though it will have no
   functional commands yet.
 
-### Phase 1 — Heuristic Baseline (Duration: 1-2 weeks)
+### Phase 1 — heuristic baseline (duration: 1-2 weeks)
 
 This phase delivers the first end-to-end, functional version of the scorer,
 relying on fast, lightweight heuristics.
@@ -1273,7 +1273,7 @@ relying on fast, lightweight heuristics.
 - The golden-file integration tests pass, establishing a baseline for
   regression testing.
 
-### Phase 2 — Model-Backed Providers & Performance (Duration: 2 weeks)
+### Phase 2 — model-backed providers & performance (duration: 2 weeks)
 
 This phase focuses on enhancing accuracy with model-based providers and
 optimising for performance.
@@ -1297,7 +1297,7 @@ optimising for performance.
 - Initial performance metrics (latency, throughput) are recorded in
   `BENCHMARKS.md`.
 
-### Phase 3 — Evaluation & Calibration (Duration: 1 week)
+### Phase 3 — evaluation & calibration (duration: 1 week)
 
 This phase is dedicated to empirically validating the scorer's effectiveness
 and tuning its parameters.
@@ -1318,7 +1318,7 @@ and tuning its parameters.
 - The calibrated parameters are finalized and committed as the default
   configuration.
 
-### Phase 4 — Bindings & Demos (Duration: 2 weeks)
+### Phase 4 — bindings & demos (duration: 2 weeks)
 
 This phase focuses on making the crate accessible from other ecosystems and
 creating compelling demonstrations.
@@ -1338,7 +1338,7 @@ creating compelling demonstrations.
 - The demonstration notebooks are complete and successfully showcase the
   crate's value.
 
-### Phase 5 — Production Hardening (Duration: 1 week)
+### Phase 5 — production hardening (duration: 1 week)
 
 The final phase adds the remaining features required for robust, secure, and
 observable production deployment.
@@ -1360,7 +1360,7 @@ observable production deployment.
   implemented and tested.
 - The final project is ready for its first official release.
 
-## 10. Integration into a Logic-Augmented Generation (LAG) System
+## 10. Integration into a logic-augmented generation (LAG) system
 
 The `lag_complexity` crate is not an end in itself; it is a critical enabling
 component for more advanced AI reasoning systems, specifically those built on
@@ -1368,7 +1368,7 @@ the Logic-Augmented Generation (LAG) paradigm. Its primary function is to serve
 as the "cognitive clutch" within an agent's decision-making loop, providing the
 necessary signal to switch between different modes of problem-solving.
 
-### The "Cognitive Clutch" Analogy
+### The "cognitive clutch" analogy
 
 In a vehicle, a clutch engages or disengages power from the engine to the
 transmission, allowing the driver to change gears. Similarly, the
@@ -1386,7 +1386,7 @@ decide which "gear" to use for processing it.
   breaks the problem down into smaller parts, and then tackles them
   systematically. This is slower but more robust and reliable.
 
-### Control Flow in a LAG Agent
+### Control flow in a LAG agent
 
 The integration of the crate into a LAG agent's control loop can be visualized
 as follows:
@@ -1414,7 +1414,7 @@ as follows:
    sub-questions are answered and a final answer can be synthesised, or a
    halting condition is met.
 
-### Integrating Halting Conditions
+### Integrating halting conditions
 
 The `lag_complexity` crate provides a unified configuration point for the
 agent's "Logical Terminator," a crucial safety mechanism to prevent infinite
@@ -1455,7 +1455,7 @@ modes, enabling the construction of agents that can dynamically adapt their
 problem-solving strategy to the complexity of the challenge, a hallmark of more
 advanced and robust artificial intelligence.
 
-## Conclusion: A Foundation for Principled and Performant AI Reasoning
+## Conclusion: a foundation for principled and performant AI reasoning
 
 This design proposal outlines a comprehensive blueprint for the
 `lag_complexity` Rust crate, a component engineered to be a cornerstone of

--- a/docs/lag-complexity-function-design.md
+++ b/docs/lag-complexity-function-design.md
@@ -21,7 +21,7 @@ errors through the reasoning chain.4
 
 The Logic-Augmented Generation (LAG) paradigm offers a principled alternative
 to address these shortcomings.3 Inspired by Cartesian principles of methodical
-problem-solving, LAG introduces a "reasoning-first" pipeline that prioritises
+problem-solving, LAG introduces a "reasoning-first" pipeline that prioritizes
 systematic question decomposition and dependency-aware resolution over
 immediate, brute-force retrieval.4 This approach represents a significant
 architectural shift, moving from purely semantic pattern matching toward a more
@@ -81,7 +81,7 @@ frameworks like Cognitive Architectures for Language Agents (CoALA), which
 advocate for distinct, interoperable components for memory, action, and
 decision-making.8 By isolating the complexity scoring logic, several
 engineering advantages are unlocked. The component can be independently
-benchmarked and optimised for performance, a critical requirement for a
+benchmarked and optimized for performance, a critical requirement for a
 function that may be on the hot path of every incoming query. Its internal
 implementations—the providers for each complexity signal—can be swapped out or
 upgraded without impacting the core logic of the consuming agent. This
@@ -98,13 +98,13 @@ scalability of the entire AI ecosystem it serves.
 The architecture of the `lag_complexity` crate is designed for modularity,
 performance, and ergonomic use. It provides a clear separation of concerns
 between the high-level API, the pluggable component providers, and the
-configuration, enabling developers to easily integrate and customise the
+configuration, enabling developers to easily integrate and customize the
 complexity scoring logic.
 
 ### Module structure and naming conventions
 
 The crate will follow standard Rust conventions, with a logical internal module
-structure to organise its components. All primary public-facing types will be
+structure to organize its components. All primary public-facing types will be
 re-exported at the crate root for convenient access.
 
 - `lag_complexity::api`: Contains the core public traits (`ComplexityFn`) and
@@ -140,7 +140,7 @@ elevated—for example, a high `ambiguity` might prompt clarification, whereas a
 high `depth` suggests decomposition. The struct derives `serde::Serialize` and
 implements `serde::Deserialize` manually to recompute `total` from the
 components, ignoring any inbound `total` field so the invariant holds when
-deserialising untrusted data.
+deserializing untrusted data.
 
 - `Error`: A comprehensive error enum will be defined using `thiserror` to
   provide structured and actionable error information.
@@ -177,8 +177,8 @@ pub trait ComplexityFn {
   low-latency execution in production.
 - The `trace` method is designed for diagnostics, debugging, and
   explainability. It will return a `Trace` struct containing a wealth of
-  intermediate data: raw scores from each provider before normalisation, the
-  specific normalisation parameters that were applied, token counts, a list of
+  intermediate data: raw scores from each provider before normalization, the
+  specific normalization parameters that were applied, token counts, a list of
   detected heuristic patterns (e.g., conjunctions or ambiguous pronouns found),
   and the latency of each provider call. This detailed output is invaluable for
   creating golden-file tests (Section 5.3), debugging scoring anomalies, and
@@ -255,17 +255,17 @@ higher-level failure types.
 
 ### Configuration (ScoringConfig and sub-types)
 
-The ScoringConfig struct and its components provide a centralised, declarative
+The ScoringConfig struct and its components provide a centralized, declarative
 way to tune the behaviour of the scoring engine. The entire structure will be
-deserialisable from a TOML file using serde, allowing operators to adjust
+deserializable from a TOML file using serde, allowing operators to adjust
 parameters in different environments (development, staging, production) without
 recompiling the application.
 
 - ScoringConfig: The top-level configuration object.
 - ScopingConfig: Configures how semantic scope is measured. The initial
   variant, Variance, accepts a window size and all configuration types derive
-  Serialise/Deserialise for convenient loading.
-- Sigma: An enum representing the normalisation strategy. This provides
+  Serialize/Deserialize for convenient loading.
+- Sigma: An enum representing the normalization strategy. This provides
   statistical flexibility to adapt to different distributions of raw scores.
 
 ```rust
@@ -317,7 +317,7 @@ Cargo's feature flag system will be used extensively to manage optional
 dependencies and conditional compilation, creating a highly flexible and lean
 library.
 
-The selection of default features is a deliberate design choice prioritising
+The selection of default features is a deliberate design choice prioritizing
 security and ease of use. By disabling `provider-api` by default, the crate
 adheres to the principle of least privilege, preventing any unintended network
 activity unless explicitly opted into by the developer.17 This is a critical
@@ -435,12 +435,12 @@ and logical complexity.22
 - **Comparative Structures:** It will detect phrases indicative of comparison,
   such as "compared to," "versus," "as opposed to," and the use of comparative
   adjectives ("more than," "less than").
-- **Dependency Chains:** It will penalise sequences of prepositional phrases,
+- **Dependency Chains:** It will penalize sequences of prepositional phrases,
   particularly possessive chains (e.g., "the name of the director of the sequel
   to the movie..."), which often signal nested entity relationships.
 - **Relative Clauses:** It will increment the score for clauses introduced by
   relative pronouns like "who," "which," "that," and "whose."
-- **Enumerations:** It will recognise explicit lists and enumerations (e.g.,
+- **Enumerations:** It will recognize explicit lists and enumerations (e.g.,
   "What are the differences between A, B, and C?").
 - **Aggregation:** The final heuristic score will be a weighted sum of the
   counts of these features. The weights will be empirically tuned against a
@@ -501,7 +501,7 @@ English text.25
   ambiguous entities (e.g., "Mercury": planet, god, element, car brand; "Nile":
   river, band). An NER pre-pass (even a simple regex-based one) will identify
   these terms and increment the score.
-- **Ellipsis and Vagueness:** The score will be penalised for vague quantifiers
+- **Ellipsis and Vagueness:** The score will be penalized for vague quantifiers
   ("some," "a few," "several") and deictic terms ("here," "there," "then") that
   lack a concrete anchor in the query's context.
 - **Aggregation:** The scores from these risk factors will be combined into a
@@ -546,18 +546,18 @@ production-oriented, industrial-grade system.
 | **ONNX Classifier** | Medium   | Low (~5-20ms)   | Low (local CPU)    | `ort` crate, model file     | Production systems needing a balance of speed and accuracy.          |
 | **External LLM**    | High     | High (500ms+)   | High               | `reqwest`, `tokio`, API key | Systems where accuracy is paramount and latency/cost are acceptable. |
 
-## 3. Configuration deep dive: normalisation, scheduling, and halting
+## 3. Configuration deep dive: normalization, scheduling, and halting
 
 Effective configuration is central to the `lag_complexity` crate's
 adaptability. The `ScoringConfig` structure provides fine-grained control over
 how raw signals are processed and interpreted, allowing the system to be tuned
 for specific domains and performance requirements.
 
-### Normalisation (sigma)
+### Normalization (sigma)
 
 The raw scores produced by the various providers—embedding variance, heuristic
 counts, or model outputs—exist on different, arbitrary scales. The `Sigma`
-normalisation module transforms these raw scores into a consistent, comparable
+normalization module transforms these raw scores into a consistent, comparable
 range, typically [0, 1], so they can be meaningfully aggregated into the final
 `CL(q)` score.
 
@@ -568,7 +568,7 @@ range, typically [0, 1], so they can be meaningfully aggregated into the final
   the 1st and 99th percentiles of the expected score distribution, rather than
   the absolute minimum and maximum. Any value below `p01` is clamped to 0, and
   any value above `p99` is clamped to 1.
-- `Sigma::ZScore { mean, std }`: This method standardises scores by subtracting
+- `Sigma::ZScore { mean, std }`: This method standardizes scores by subtracting
   the mean and dividing by the standard deviation of the expected distribution.
   The resulting Z-score is then typically passed through a sigmoid function to
   map it to the [0, 1] range. This approach is effective when the raw scores
@@ -583,7 +583,7 @@ range, typically [0, 1], so they can be meaningfully aggregated into the final
   effectiveness depends entirely on being calibrated against a dataset of
   queries that is representative of the target domain. The crate will ship with
   a set of default parameters calibrated on a general-purpose web question
-  dataset. However, the documentation will strongly emphasise that for optimal
+  dataset. However, the documentation will strongly emphasize that for optimal
   performance, users must perform their own calibration step using
   domain-specific data and the evaluation harness provided by the crate (see
   Section 5).
@@ -650,7 +650,7 @@ ensure the `lag_complexity` crate is robust and operationally sound.
 ### Concurrency and parallelism
 
 Rust's fearless concurrency model is a primary reason for its selection for
-this task. The crate will leverage this capability to maximise throughput.
+this task. The crate will leverage this capability to maximize throughput.
 
 - **Batch Processing:** The `ComplexityFn` trait will expose a
   `score_batch(&self, q: &[&str]) -> Vec<Result<Complexity, Error>>` method.
@@ -757,7 +757,7 @@ deterministic for a given input and configuration.
 - **Seeding:** Any internal processes that rely on random number generation
   (e.g., certain model layers, stochastic preprocessing) will be explicitly
   seeded.
-- **Configuration Snapshotting:** The calibrated normalisation parameters
+- **Configuration Snapshotting:** The calibrated normalization parameters
   (`Sigma`) and heuristic weights will be stored in a version-controlled
   configuration file, ensuring that the exact parameters used for evaluation
   are captured and reproducible.
@@ -781,7 +781,7 @@ in isolation.
 
 - The variance calculation will be tested against known inputs and edge cases
   (e.g., zero-length vectors, vectors with all identical elements).
-- Each `Sigma` normalisation implementation will be tested to ensure it
+- Each `Sigma` normalization implementation will be tested to ensure it
   correctly scales inputs according to its formula and handles values outside
   the calibrated range gracefully (clipping).
 - The `Schedule::ExpDecay` logic will be tested to confirm that the threshold
@@ -808,7 +808,7 @@ test writers might miss.
 - The `score(q)` function must never panic for any valid UTF-8 string `q`.
 - All components of the returned `Complexity` struct (`total`, `scope`,
   `depth`, `ambiguity`) must be non-negative.
-- **Behavioral Properties:**
+- **Behavioural properties:**
 
 - **Idempotence:** `score(q)` should be equal to `score(q.clone())`.
 - **Scope Order-Insensitivity:** For the `ScopeVariance` component,
@@ -828,16 +828,16 @@ components of the crate work correctly together.
   A set of approximately 50 curated queries representing a wide range of
   complexity types (single-hop, multi-hop, ambiguous, high-scope, simple, and
   nonsensical) will be stored in a "golden file." The integration test will
-  execute the `trace()` method for each query and serialise the detailed
+  execute the `trace()` method for each query and serialize the detailed
   `Trace` object to a snapshot file. This snapshot will be committed to version
   control. On subsequent test runs, the new output will be compared against the
   golden snapshot; any discrepancies will fail the test, immediately flagging
   unintended changes in behaviour from modifications to heuristics, models, or
-  normalisation logic.
+  normalization logic.
 - **Provider and Feature Flag Integration:** Specific integration tests will be
   compiled only when certain feature flags are enabled (e.g.,
   `#[cfg(feature = "provider-api")]`). These tests will ensure that API-based
-  providers correctly serialise requests and deserialise responses (using mock
+  providers correctly serialize requests and deserialize responses (using mock
   servers like `wiremock`) and that ONNX models can be loaded and executed
   successfully.
 
@@ -911,7 +911,7 @@ Benchmarks will reside in the `benches/` directory and can be executed via
 ### Micro-benchmarks
 
 These benchmarks will isolate and measure the performance of individual,
-critical components to identify potential bottlenecks and guide optimisation
+critical components to identify potential bottlenecks and guide optimization
 efforts.
 
 - **Provider Latency:**
@@ -929,7 +929,7 @@ efforts.
 - **Computational Overhead:**
 
 - The time taken for the variance calculation and the application of `Sigma`
-  normalisation will be measured to ensure they contribute negligibly to the
+  normalization will be measured to ensure they contribute negligibly to the
   overall latency.
 
 ### Macro-benchmarks
@@ -1004,7 +1004,7 @@ experience of the complexity metric in action.
   area where a user can type or paste a question. As the user types, the input
   will be passed to the WASM module in real-time. The application will display:
 
-- A set of gauges or progress bars visualizing the normalised scores for
+- A set of gauges or progress bars visualizing the normalized scores for
   `total`, `scope`, `depth`, and `ambiguity`. These will update dynamically,
   providing instant feedback.
 - A color-coded overall complexity indicator (e.g., Green for Low, Yellow for
@@ -1128,7 +1128,7 @@ where
         let raw_depth = d_res?;
         let raw_ambiguity = a_res?;
 
-        // Calculate variance and apply normalisation
+        // Calculate variance and apply normalization
         let variance = calculate_variance(&embedding);
         let scope = self.cfg.sigma.apply(variance);
         let depth = self.cfg.sigma.apply(raw_depth);
@@ -1151,13 +1151,13 @@ where
 This example clearly illustrates the composition pattern, the use of
 `rayon::join` for concurrent provider execution, and the conditional
 compilation based on the `rayon` feature flag. It walks through the logical
-flow from raw provider outputs to the final, normalised, and weighted
+flow from raw provider outputs to the final, normalized, and weighted
 `Complexity` score.
 
 ### Configuration from file
 
 To promote best practices for configuration management, an example will show
-how to deserialise the `ScoringConfig` from a TOML file. This allows for easy
+how to deserialize the `ScoringConfig` from a TOML file. This allows for easy
 tuning of the system's behaviour without requiring code changes or
 recompilation.
 
@@ -1171,8 +1171,8 @@ mad = 0.1
 
 [weights]
 scope = 1.0
-depth = 1.2 # Slightly emphasise reasoning steps
-ambiguity = 1.5 # Strongly emphasise ambiguity for safety
+depth = 1.2 # Slightly emphasize reasoning steps
+ambiguity = 1.5 # Strongly emphasize ambiguity for safety
 
 [schedule]
 type = "ExpDecay"
@@ -1237,19 +1237,19 @@ defining the primary public interfaces.
 
 - **Tasks:**
 
-- Initialise the Rust project using `cargo new`.
+- Initialize the Rust project using `cargo new`.
 - Define all public traits (`ComplexityFn`, `EmbeddingProvider`,
   `DepthEstimator`, `AmbiguityEstimator`).
 - Define all public data structures (`Complexity`, `Trace`, `ScoringConfig` and
   its sub-types) and derive `serde` traits for configuration types.
 - Implement the mathematical logic for variance calculation and all `Sigma`
-  normalisation strategies.
+  normalization strategies.
 - Create the stub for the `lagc` command-line interface binary using the `clap`
   crate.63
 - **Acceptance Criteria:**
 
 - The crate and all its core types compile successfully.
-- A comprehensive suite of unit tests for the mathematical and normalisation
+- A comprehensive suite of unit tests for the mathematical and normalization
   logic passes.
 - The `lagc` CLI application can be built and executed, though it will have no
   functional commands yet.
@@ -1276,7 +1276,7 @@ relying on fast, lightweight heuristics.
 ### Phase 2 — model-backed providers & performance (duration: 2 weeks)
 
 This phase focuses on enhancing accuracy with model-based providers and
-optimising for performance.
+optimizing for performance.
 
 - **Tasks:**
 
@@ -1309,7 +1309,7 @@ and tuning its parameters.
 - Implement the calculation of correlation (`Kendall-τ`, `Spearman-ρ`) and
   calibration (`ECE`) metrics.
 - Run the evaluation harness and analyse the results to fine-tune the `Sigma`
-  normalisation parameters and the weights within the heuristic models.
+  normalization parameters and the weights within the heuristic models.
 - **Acceptance Criteria:**
 
 - The evaluation harness successfully generates a report (`EVALUATION.md`).
@@ -1350,7 +1350,7 @@ observable production deployment.
 - Implement the `with_redaction_hook` method for PII scrubbing.
 - Write comprehensive `rustdoc` documentation for all public APIs, including
   detailed usage examples.
-- Finalise the `README.md` to include installation instructions, usage
+- Finalize the `README.md` to include installation instructions, usage
   examples, and links to benchmarks and evaluation reports.
 - **Acceptance Criteria:**
 
@@ -1409,9 +1409,9 @@ as follows:
   resolution. The agent proceeds with its standard execution flow: retrieve
   context relevant to qt​ and generate an answer.
 
-1. **Synthesise and Repeat:** Once a sub-question is resolved, its answer is
+1. **Synthesize and repeat:** Once a sub-question is resolved, its answer is
    added to the context for subsequent steps. The loop continues until all
-   sub-questions are answered and a final answer can be synthesised, or a
+   sub-questions are answered and a final answer can be synthesized, or a
    halting condition is met.
 
 ### Integrating halting conditions
@@ -1439,7 +1439,7 @@ control flow.
 The development of this crate is a foundational step toward building more
 sophisticated language agents that are capable of metacognition—the ability to
 reason about their own reasoning process. Frameworks for advanced AI, such as
-Cognitive Architectures for Language Agents (CoALA), emphasise the need for
+Cognitive Architectures for Language Agents (CoALA), emphasize the need for
 agents to possess distinct modules for memory, action, and deliberative
 decision-making.8 The
 


### PR DESCRIPTION
## Summary
- normalise design doc headings and remove stray punctuation
- use `plaintext` fences for non-code examples
- adopt en-GB spelling across the design proposal

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_68a36f11cac08322b21e35602c95ff71

## Summary by Sourcery

Tidy the design proposal documentation by standardizing headings and punctuation, switching non-code examples to plaintext fences, and adopting en-GB spelling throughout

Documentation:
- Normalize design doc headings and remove stray punctuation
- Replace text-formatted fences with plaintext code fences for examples
- Adopt British English spelling conventions across the design proposal