### PR TITLE
Scaffold lagc CLI with ortho-config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,6 +251,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -545,12 +551,14 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ortho_config"
-version = "0.3.0"
-source = "git+https://github.com/leynos/ortho-config.git?rev=adfe967eb95c03c8711a350ac555ea193f81bc40#adfe967eb95c03c8711a350ac555ea193f81bc40"
+version = "0.5.0-alpha2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75bd38d3ab2439bb3d29c188fa807e000fbc25e9d720c6117c199d1a97c7a946"
 dependencies = [
  "clap",
  "clap-dispatch",
  "directories",
+ "dunce",
  "figment",
  "ortho_config_macros",
  "serde",
@@ -563,8 +571,9 @@ dependencies = [
 
 [[package]]
 name = "ortho_config_macros"
-version = "0.3.0"
-source = "git+https://github.com/leynos/ortho-config.git?rev=adfe967eb95c03c8711a350ac555ea193f81bc40#adfe967eb95c03c8711a350ac555ea193f81bc40"
+version = "0.5.0-alpha2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1afa9a9c8e9213c5464bcc09eec873fbe0407b0a9288f9ef120323b6b2c44c01"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,6 +273,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "eyre"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -476,6 +486,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "indenter"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
+
+[[package]]
 name = "indexmap"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -529,6 +545,7 @@ version = "0.1.0"
 dependencies = [
  "assert_cmd",
  "clap",
+ "eyre",
  "figment",
  "figment-json5",
  "json5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,16 +12,293 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
+name = "assert_cmd"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bd389a4b2970a01282ee455294913c0a43724daedcd1a24c3eb0ec1c1320b66"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "doc-comment",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "bitflags"
+version = "2.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
+name = "bytemuck"
+version = "1.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
+name = "clap"
+version = "4.5.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc0e74a703892159f5ae7d3aac52c8e6c392f5ae5f359c70b5881d60aaac318"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap-dispatch"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a558b9547b590c876e46e301da15d3b0e93b0384fd50d2c7870f7ea86760df5"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3e7f4214277f3c7aa526a59dd3fbe306a370daee1f8b7b8c987069cd8e888a8"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14cb31bb0a7d536caef2639baa7fad459e15c3144efefa6dbd1c84562c4739f6"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "directories"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys",
+]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "figment"
+version = "0.10.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
+dependencies = [
+ "atomic",
+ "parking_lot",
+ "pear",
+ "serde",
+ "serde_yaml",
+ "tempfile",
+ "toml",
+ "uncased",
+ "version_check",
+]
+
+[[package]]
+name = "figment-json5"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26f6982da09e166efe7dc3c5cf1fe01ef85419733eb188c0df0b571eda9e8a81"
+dependencies = [
+ "figment",
+ "json5",
+ "serde",
+]
 
 [[package]]
 name = "futures-core"
@@ -67,19 +344,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
+]
+
+[[package]]
 name = "gherkin"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20b79820c0df536d1f3a089a2fa958f61cb96ce9e0f3f8f507f5a31179567755"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "peg",
  "quote",
  "serde",
  "serde_json",
  "syn",
  "textwrap",
- "thiserror",
+ "thiserror 1.0.69",
  "typed-builder",
 ]
 
@@ -102,6 +412,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "indexmap"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,6 +426,12 @@ dependencies = [
  "equivalent",
  "hashbrown",
 ]
+
+[[package]]
+name = "inlinable_string"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
 name = "inventory"
@@ -121,21 +443,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "json5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
+]
+
+[[package]]
 name = "lag-complexity"
 version = "0.1.0"
 dependencies = [
+ "assert_cmd",
+ "clap",
+ "figment",
+ "figment-json5",
+ "json5",
+ "ortho_config",
  "rstest",
  "rstest-bdd",
  "rstest-bdd-macros",
  "serde",
  "serde_json",
- "thiserror",
+ "serde_yaml",
+ "thiserror 1.0.69",
+ "toml",
+ "uncased",
+ "xdg",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.175"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+
+[[package]]
+name = "libredox"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
+dependencies = [
+ "bitflags",
+ "libc",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
+name = "lock_api"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+dependencies = [
+ "autocfg",
+ "scopeguard",
 ]
 
 [[package]]
@@ -143,6 +524,98 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ortho_config"
+version = "0.3.0"
+source = "git+https://github.com/leynos/ortho-config.git?rev=adfe967eb95c03c8711a350ac555ea193f81bc40#adfe967eb95c03c8711a350ac555ea193f81bc40"
+dependencies = [
+ "clap",
+ "clap-dispatch",
+ "directories",
+ "figment",
+ "ortho_config_macros",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "toml",
+ "uncased",
+ "xdg",
+]
+
+[[package]]
+name = "ortho_config_macros"
+version = "0.3.0"
+source = "git+https://github.com/leynos/ortho-config.git?rev=adfe967eb95c03c8711a350ac555ea193f81bc40#adfe967eb95c03c8711a350ac555ea193f81bc40"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "pear"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdeeaa00ce488657faba8ebf44ab9361f9365a97bd39ffb8a60663f57ff4b467"
+dependencies = [
+ "inlinable_string",
+ "pear_codegen",
+ "yansi",
+]
+
+[[package]]
+name = "pear_codegen"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bab5b985dc082b345f812b7df84e1bef27e7207b39e448439ba8bd69c93f147"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "peg"
@@ -172,6 +645,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555b1514d2d99d78150d3c799d4c357a3e2c2a8062cd108e93a06d9057629c5"
 
 [[package]]
+name = "pest"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
+dependencies = [
+ "memchr",
+ "thiserror 2.0.16",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb056d9e8ea77922845ec74a1c4e8fb17e7c218cc4fc11a15c5d25e189aa40bc"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e404e638f781eb3202dc82db6760c8ae8a1eeef7fb3fa8264b2ef280504966"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd1101f170f5903fde0914f899bb503d9ff5271d7ba76bbb70bea63690cc0d5"
+dependencies = [
+ "pest",
+ "sha2",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -182,6 +699,33 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "proc-macro-crate"
@@ -202,12 +746,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+ "yansi",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -264,7 +847,7 @@ dependencies = [
  "gherkin",
  "inventory",
  "regex",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -307,6 +890,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -317,6 +913,12 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
@@ -357,16 +959,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
 name = "smawk"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -378,6 +1025,25 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "tempfile"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.3",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "textwrap"
@@ -396,7 +1062,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
+dependencies = [
+ "thiserror-impl 2.0.16",
 ]
 
 [[package]]
@@ -411,10 +1086,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror-impl"
+version = "2.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -423,9 +1124,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
+ "toml_write",
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "typed-builder"
@@ -448,6 +1158,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "uncased"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -466,6 +1197,192 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.3",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
 name = "winnow"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -473,3 +1390,24 @@ checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "xdg"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fb433233f2df9344722454bc7e96465c9d03bff9d77c248f9e7523fe79585b5"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,10 +307,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-macro"
@@ -322,6 +364,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
@@ -341,9 +389,13 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -480,6 +532,7 @@ dependencies = [
  "figment",
  "figment-json5",
  "json5",
+ "once_cell",
  "ortho_config",
  "rstest",
  "rstest-bdd",
@@ -487,6 +540,9 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "serial_test",
+ "shlex",
+ "tempfile",
  "thiserror 1.0.69",
  "toml",
  "uncased",
@@ -524,6 +580,12 @@ dependencies = [
  "autocfg",
  "scopeguard",
 ]
+
+[[package]]
+name = "log"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "memchr"
@@ -924,10 +986,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "semver"
@@ -990,6 +1067,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+dependencies = [
+ "futures",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -999,6 +1101,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "slab"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,6 +298,7 @@ dependencies = [
  "parking_lot",
  "pear",
  "serde",
+ "serde_json",
  "serde_yaml",
  "tempfile",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ clap = { version = "4.5", features = ["derive"], optional = true }
 figment = { version = "0.10", default-features = false, features = ["env"], optional = true }
 uncased = { version = "0.9", optional = true }
 xdg = { version = "3", optional = true }
+eyre = { version = "0.6", optional = true }
 serde_json = "1.0"
 figment-json5 = { version = "0.1", optional = true }
 json5 = { version = "0.4", optional = true }
@@ -20,7 +21,7 @@ toml = { version = "0.8", optional = true }
 
 [features]
 default = ["toml", "cli"]
-cli = ["dep:ortho_config", "dep:clap", "dep:figment", "dep:uncased", "dep:xdg"]
+cli = ["dep:ortho_config", "dep:clap", "dep:figment", "dep:uncased", "dep:xdg", "dep:eyre"]
 json5 = ["cli", "dep:figment-json5", "dep:json5"]
 yaml = ["cli", "figment/yaml", "dep:serde_yaml"]
 toml = ["cli", "figment/toml", "dep:toml"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ toml = { version = "0.8", optional = true }
 
 [features]
 default = ["toml", "cli"]
-cli = ["dep:ortho_config", "dep:clap", "dep:figment", "dep:uncased", "dep:xdg", "dep:eyre"]
+cli = ["dep:ortho_config", "dep:clap", "dep:figment", "dep:uncased", "dep:xdg", "dep:eyre", "figment/json"]
 json5 = ["cli", "dep:figment-json5", "dep:json5"]
 yaml = ["cli", "figment/yaml", "dep:serde_yaml"]
 toml = ["cli", "figment/toml", "dep:toml"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,11 @@ edition = "2024"
 
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
-ortho_config = "0.5.0-alpha2"
-clap = { version = "4.5", features = ["derive"] }
-figment = { version = "0.10", default-features = false, features = ["env"] }
-uncased = "0.9"
-xdg = "3"
+ortho_config = { version = "0.5.0-alpha2", optional = true }
+clap = { version = "4.5", features = ["derive"], optional = true }
+figment = { version = "0.10", default-features = false, features = ["env"], optional = true }
+uncased = { version = "0.9", optional = true }
+xdg = { version = "3", optional = true }
 serde_json = "1.0"
 figment-json5 = { version = "0.1", optional = true }
 json5 = { version = "0.4", optional = true }
@@ -19,10 +19,16 @@ serde_yaml = { version = "0.9", optional = true }
 toml = { version = "0.8", optional = true }
 
 [features]
-default = ["toml"]
-json5 = ["dep:figment-json5", "dep:json5"]
-yaml = ["figment/yaml", "dep:serde_yaml"]
-toml = ["figment/toml", "dep:toml"]
+default = ["toml", "cli"]
+cli = ["dep:ortho_config", "dep:clap", "dep:figment", "dep:uncased", "dep:xdg"]
+json5 = ["cli", "dep:figment-json5", "dep:json5"]
+yaml = ["cli", "figment/yaml", "dep:serde_yaml"]
+toml = ["cli", "figment/toml", "dep:toml"]
+
+[[bin]]
+name = "lagc"
+path = "src/bin/lagc.rs"
+required-features = ["cli"]
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }
@@ -64,3 +70,7 @@ rstest = "0.26.1"
 rstest-bdd = { git = "https://github.com/leynos/rstest-bdd.git", rev = "7a298dafa1b0c43b4aa711f180732234ad999e86" }
 rstest-bdd-macros = { git = "https://github.com/leynos/rstest-bdd.git", rev = "7a298dafa1b0c43b4aa711f180732234ad999e86" }
 assert_cmd = "2.0"
+once_cell = "1.19"
+shlex = "1.3"
+tempfile = "3.10"
+serial_test = "3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
-ortho_config = { git = "https://github.com/leynos/ortho-config.git", rev = "adfe967eb95c03c8711a350ac555ea193f81bc40" }
+ortho_config = "0.5.0-alpha2"
 clap = { version = "4.5", features = ["derive"] }
 figment = { version = "0.10", default-features = false, features = ["env"] }
 uncased = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,22 @@ edition = "2024"
 
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
+ortho_config = { git = "https://github.com/leynos/ortho-config.git", rev = "adfe967eb95c03c8711a350ac555ea193f81bc40" }
+clap = { version = "4.5", features = ["derive"] }
+figment = { version = "0.10", default-features = false, features = ["env"] }
+uncased = "0.9"
+xdg = "3"
+serde_json = "1.0"
+figment-json5 = { version = "0.1", optional = true }
+json5 = { version = "0.4", optional = true }
+serde_yaml = { version = "0.9", optional = true }
+toml = { version = "0.8", optional = true }
+
+[features]
+default = ["toml"]
+json5 = ["dep:figment-json5", "dep:json5"]
+yaml = ["figment/yaml", "dep:serde_yaml"]
+toml = ["figment/toml", "dep:toml"]
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }
@@ -47,4 +63,4 @@ float_arithmetic = "deny"
 rstest = "0.26.1"
 rstest-bdd = { git = "https://github.com/leynos/rstest-bdd.git", rev = "7a298dafa1b0c43b4aa711f180732234ad999e86" }
 rstest-bdd-macros = { git = "https://github.com/leynos/rstest-bdd.git", rev = "7a298dafa1b0c43b4aa711f180732234ad999e86" }
-serde_json = "1.0"
+assert_cmd = "2.0"

--- a/docs/lag-complexity-function-design.md
+++ b/docs/lag-complexity-function-design.md
@@ -335,16 +335,16 @@ guiding them toward safe and efficient deployment patterns.
 
 #### Table 1: feature flag specification
 
-| Feature Flag      | Dependencies                                      | Purpose                                                                               | Default |
-| ----------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------- | ------- |
-| `provider-api`    | `reqwest`, `tokio`                                | Enables providers that call external HTTP APIs for embeddings or LLM-based estimates. | Off     |
-| `provider-tch`    | `tch`                                             | Enables local transformer models via the `tch` crate (LibTorch backend).              | Off     |
-| `provider-candle` | `candle-core`, `candle-nn`, `candle-transformers` | Enables local transformer models via the pure-Rust `candle` framework.                | On      |
-| `onnx`            | `ort`                                             | Enables ONNX Runtime for lightweight classifier models.                               | On      |
-| `rayon`           | `rayon`                                           | Enables parallel execution for batch scoring and concurrent provider calls.           | On      |
-| `python`          | `pyo3`                                            | Builds Python bindings for the crate.                                                 | Off     |
-| `wasm`            | `wasm-bindgen`, `js-sys`                          | Builds a WebAssembly module for browser/JS environments.                              | Off     |
-| `cli`             | `ortho_config`                                    | Builds the `lagc` command-line interface binary.                                      | On      |
+| Feature Flag      | Dependencies                                        | Purpose                                                                               | Default |
+| ----------------- | --------------------------------------------------- | ------------------------------------------------------------------------------------- | ------- |
+| `provider-api`    | `reqwest`, `tokio`                                  | Enables providers that call external HTTP APIs for embeddings or LLM-based estimates. | Off     |
+| `provider-tch`    | `tch`                                               | Enables local transformer models via the `tch` crate (LibTorch backend).              | Off     |
+| `provider-candle` | `candle-core`, `candle-nn`, `candle-transformers`   | Enables local transformer models via the pure-Rust `candle` framework.                | On      |
+| `onnx`            | `ort`                                               | Enables ONNX Runtime for lightweight classifier models.                               | On      |
+| `rayon`           | `rayon`                                             | Enables parallel execution for batch scoring and concurrent provider calls.           | On      |
+| `python`          | `pyo3`                                              | Builds Python bindings for the crate.                                                 | Off     |
+| `wasm`            | `wasm-bindgen`, `js-sys`                            | Builds a WebAssembly module for browser/JS environments.                              | Off     |
+| `cli`             | `ortho_config`, `clap`, `figment`, `uncased`, `xdg` | Builds the `lagc` command-line interface binary.                                      | On      |
 
 ## 2. Component signal implementations
 
@@ -1260,9 +1260,10 @@ defining the primary public interfaces.
 - Implement the mathematical logic for variance calculation and all `Sigma`
   normalization strategies.
 - Create the stub for the `lagc` command-line interface binary using the
-  `ortho-config` crate (v0.5.0-alpha2 from crates.io), which layers
-  command-line arguments, environment variables and configuration files without
-  extra boilerplate.
+  `ortho_config` crate (published as `ortho-config` on crates.io)\
+  [^hyphen-underscore], which layers command-line arguments, environment
+  variables (prefixed with `LAGC_`) and configuration files without extra
+  boilerplate.
 - **Acceptance Criteria:**
 
 - The crate and all its core types compile successfully.
@@ -1512,3 +1513,7 @@ systems that are more robust, explainable, and aligned with the principles of
 structured human reasoning. Its successful implementation will represent a
 significant step toward creating AI that can not only answer questions but can
 also understand when a question requires deeper thought.
+
+[^hyphen-underscore]: Cargo converts hyphens to underscores for import paths.
+                      The package is `ortho-config` on crates.io and is
+                      imported as `ortho_config` in code.

--- a/docs/lag-complexity-function-design.md
+++ b/docs/lag-complexity-function-design.md
@@ -1262,8 +1262,9 @@ defining the primary public interfaces.
 - Create the stub for the `lagc` command-line interface binary using the
   `ortho_config` crate (published as `ortho-config` on crates.io)
   [^hyphen-underscore], which layers command-line arguments, environment
-  variables (prefixed with `LAGC_`) and configuration files without extra
-  boilerplate. Environment values override file values.
+  variables (prefixed with `LAGC_`), and configuration files without extra
+  boilerplate. Precedence is: command-line arguments > environment variables
+  > configuration files.
 - **Acceptance Criteria:**
 
 - The crate and all its core types compile successfully.

--- a/docs/lag-complexity-function-design.md
+++ b/docs/lag-complexity-function-design.md
@@ -335,16 +335,16 @@ guiding them toward safe and efficient deployment patterns.
 
 #### Table 1: feature flag specification
 
-| Feature Flag      | Dependencies                                        | Purpose                                                                               | Default |
-| ----------------- | --------------------------------------------------- | ------------------------------------------------------------------------------------- | ------- |
-| `provider-api`    | `reqwest`, `tokio`                                  | Enables providers that call external HTTP APIs for embeddings or LLM-based estimates. | Off     |
-| `provider-tch`    | `tch`                                               | Enables local transformer models via the `tch` crate (LibTorch backend).              | Off     |
-| `provider-candle` | `candle-core`, `candle-nn`, `candle-transformers`   | Enables local transformer models via the pure-Rust `candle` framework.                | On      |
-| `onnx`            | `ort`                                               | Enables ONNX Runtime for lightweight classifier models.                               | On      |
-| `rayon`           | `rayon`                                             | Enables parallel execution for batch scoring and concurrent provider calls.           | On      |
-| `python`          | `pyo3`                                              | Builds Python bindings for the crate.                                                 | Off     |
-| `wasm`            | `wasm-bindgen`, `js-sys`                            | Builds a WebAssembly module for browser/JS environments.                              | Off     |
-| `cli`             | `ortho_config`, `clap`, `figment`, `uncased`, `xdg` | Builds the `lagc` command-line interface binary.                                      | On      |
+| Feature Flag      | Dependencies                                                | Purpose                                                                               | Default |
+| ----------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------------- | ------- |
+| `provider-api`    | `reqwest`, `tokio`                                          | Enables providers that call external HTTP APIs for embeddings or LLM-based estimates. | Off     |
+| `provider-tch`    | `tch`                                                       | Enables local transformer models via the `tch` crate (LibTorch backend).              | Off     |
+| `provider-candle` | `candle-core`, `candle-nn`, `candle-transformers`           | Enables local transformer models via the pure-Rust `candle` framework.                | On      |
+| `onnx`            | `ort`                                                       | Enables ONNX Runtime for lightweight classifier models.                               | On      |
+| `rayon`           | `rayon`                                                     | Enables parallel execution for batch scoring and concurrent provider calls.           | On      |
+| `python`          | `pyo3`                                                      | Builds Python bindings for the crate.                                                 | Off     |
+| `wasm`            | `wasm-bindgen`, `js-sys`                                    | Builds a WebAssembly module for browser/JS environments.                              | Off     |
+| `cli`             | `ortho_config`, `clap`, `figment`, `uncased`, `xdg`, `eyre` | Builds the `lagc` command-line interface binary.                                      | On      |
 
 ## 2. Component signal implementations
 

--- a/docs/lag-complexity-function-design.md
+++ b/docs/lag-complexity-function-design.md
@@ -344,7 +344,7 @@ guiding them toward safe and efficient deployment patterns.
 | `rayon`           | `rayon`                                           | Enables parallel execution for batch scoring and concurrent provider calls.           | On      |
 | `python`          | `pyo3`                                            | Builds Python bindings for the crate.                                                 | Off     |
 | `wasm`            | `wasm-bindgen`, `js-sys`                          | Builds a WebAssembly module for browser/JS environments.                              | Off     |
-| `cli`             | `clap`                                            | Builds the `lagc` command-line interface binary.                                      | On      |
+| `cli`             | `ortho_config`                                    | Builds the `lagc` command-line interface binary.                                      | On      |
 
 ## 2. Component signal implementations
 
@@ -1259,8 +1259,9 @@ defining the primary public interfaces.
   its sub-types) and derive `serde` traits for configuration types.
 - Implement the mathematical logic for variance calculation and all `Sigma`
   normalization strategies.
-- Create the stub for the `lagc` command-line interface binary using the `clap`
-  crate.63
+- Create the stub for the `lagc` command-line interface binary using the
+  `ortho-config` crate, which layers command-line arguments, environment
+  variables and configuration files without extra boilerplate.
 - **Acceptance Criteria:**
 
 - The crate and all its core types compile successfully.

--- a/docs/lag-complexity-function-design.md
+++ b/docs/lag-complexity-function-design.md
@@ -1260,7 +1260,7 @@ defining the primary public interfaces.
 - Implement the mathematical logic for variance calculation and all `Sigma`
   normalization strategies.
 - Create the stub for the `lagc` command-line interface binary using the
-  `ortho_config` crate (published as `ortho-config` on crates.io)\
+  `ortho_config` crate (published as `ortho-config` on crates.io)
   [^hyphen-underscore], which layers command-line arguments, environment
   variables (prefixed with `LAGC_`) and configuration files without extra
   boilerplate.

--- a/docs/lag-complexity-function-design.md
+++ b/docs/lag-complexity-function-design.md
@@ -1260,8 +1260,9 @@ defining the primary public interfaces.
 - Implement the mathematical logic for variance calculation and all `Sigma`
   normalization strategies.
 - Create the stub for the `lagc` command-line interface binary using the
-  `ortho-config` crate, which layers command-line arguments, environment
-  variables and configuration files without extra boilerplate.
+  `ortho-config` crate (v0.5.0-alpha2 from crates.io), which layers
+  command-line arguments, environment variables and configuration files without
+  extra boilerplate.
 - **Acceptance Criteria:**
 
 - The crate and all its core types compile successfully.

--- a/docs/lag-complexity-function-design.md
+++ b/docs/lag-complexity-function-design.md
@@ -1263,7 +1263,7 @@ defining the primary public interfaces.
   `ortho_config` crate (published as `ortho-config` on crates.io)
   [^hyphen-underscore], which layers command-line arguments, environment
   variables (prefixed with `LAGC_`) and configuration files without extra
-  boilerplate.
+  boilerplate. Environment values override file values.
 - **Acceptance Criteria:**
 
 - The crate and all its core types compile successfully.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -12,13 +12,13 @@ primary public interfaces.
     `DepthEstimator`, `AmbiguityEstimator`).
 - [x] Implement the mathematical logic for variance calculation and all `Sigma`
   normalisation strategies.
-- [ ] Create the stub for the `lagc` command-line interface binary using the
-  `clap` crate.
+- [x] Create the stub for the `lagc` command-line interface binary using the
+  `ortho-config` crate.
 - [ ] **Acceptance Criteria**: The crate and all its core types compile
   successfully.
 - [x] **Acceptance Criteria**: A comprehensive suite of unit tests for the
   mathematical and normalisation logic passes.
-- [ ] **Acceptance Criteria**: The `lagc` CLI application can be built and run,
+- [x] **Acceptance Criteria**: The `lagc` CLI application can be built and run,
   though it will have no functional commands yet.
 
 ## Phase 1 — Heuristic Baseline (Duration: 1–2 weeks)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -12,9 +12,8 @@ primary public interfaces.
     `DepthEstimator`, `AmbiguityEstimator`).
 - [x] Implement the mathematical logic for variance calculation and all `Sigma`
   normalisation strategies.
-- [x] Create the stub for the `lagc` command-line interface binary using the
-  `ortho_config` crate (published as `ortho-config` on crates.io)
-  [^hyphen-underscore].
+- [x] Create the stub for the `lagc` CLI binary using `ortho_config`
+  (published as `ortho-config` on crates.io) [^hyphen-underscore].
 - [ ] **Acceptance Criteria**: The crate and all its core types compile
   successfully.
 - [x] **Acceptance Criteria**: A comprehensive suite of unit tests for the

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -19,8 +19,9 @@ primary public interfaces.
   successfully.
 - [x] **Acceptance Criteria**: A comprehensive suite of unit tests for the
   mathematical and normalisation logic passes.
-- [x] **Acceptance Criteria**: The `lagc` CLI application can be built and run,
-  though it will have no functional commands yet.
+- [x] **Acceptance Criteria**: The `lagc` CLI application can be built and run
+  (verify with: `cargo run --bin lagc -- --help`), though it will have no
+  functional commands yet.
 
 ## Phase 1 — Heuristic Baseline (Duration: 1–2 weeks)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,7 +13,7 @@ primary public interfaces.
 - [x] Implement the mathematical logic for variance calculation and all `Sigma`
   normalisation strategies.
 - [x] Create the stub for the `lagc` command-line interface binary using the
-  `ortho-config` crate.
+  `ortho-config` crate (v0.5.0-alpha2 from crates.io).
 - [ ] **Acceptance Criteria**: The crate and all its core types compile
   successfully.
 - [x] **Acceptance Criteria**: A comprehensive suite of unit tests for the

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,7 +13,7 @@ primary public interfaces.
 - [x] Implement the mathematical logic for variance calculation and all `Sigma`
   normalisation strategies.
 - [x] Create the stub for the `lagc` command-line interface binary using the
-  `ortho_config` crate (published as `ortho-config` on crates.io)\
+  `ortho_config` crate (published as `ortho-config` on crates.io)
   [^hyphen-underscore].
 - [ ] **Acceptance Criteria**: The crate and all its core types compile
   successfully.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,7 +13,8 @@ primary public interfaces.
 - [x] Implement the mathematical logic for variance calculation and all `Sigma`
   normalisation strategies.
 - [x] Create the stub for the `lagc` command-line interface binary using the
-  `ortho-config` crate (v0.5.0-alpha2 from crates.io).
+  `ortho_config` crate (published as `ortho-config` on crates.io)\
+  [^hyphen-underscore].
 - [ ] **Acceptance Criteria**: The crate and all its core types compile
   successfully.
 - [x] **Acceptance Criteria**: A comprehensive suite of unit tests for the
@@ -110,3 +111,7 @@ observable production deployment.
   security hooks) are implemented and tested.
 - [ ] **Acceptance Criteria**: The final project is ready for its first
   official release.
+
+[^hyphen-underscore]: Cargo converts hyphens to underscores for import paths.
+                      The package is `ortho-config` on crates.io and is
+                      imported as `ortho_config` in code.

--- a/src/bin/lagc.rs
+++ b/src/bin/lagc.rs
@@ -9,11 +9,13 @@ fn main() -> Result<()> {
     // Load configuration from CLI, environment, and config files. Future
     // subcommands will branch from these parsed arguments.
     let _cfg = <LagcArgs as ortho_config::OrthoConfig>::load().map_err(|e| {
-        if e.to_string().contains("invalid value") {
-            eyre::eyre!("invalid boolean: {e}")
-        } else {
-            e.into()
+        // Prefer typed matching over substring checks for robustness.
+        if let ortho_config::OrthoError::CliParsing(clap_err) = &e
+            && clap_err.kind() == clap::error::ErrorKind::InvalidValue
+        {
+            return eyre::eyre!("invalid boolean: {clap_err}");
         }
+        e.into()
     })?;
     Ok(())
 }

--- a/src/bin/lagc.rs
+++ b/src/bin/lagc.rs
@@ -3,7 +3,7 @@ use ortho_config::{OrthoConfig, OrthoError};
 
 #[expect(
     clippy::result_large_err,
-    reason = "OrthoError originates from external crate and is acceptable here",
+    reason = "OrthoError originates from external crate and is acceptable here"
 )]
 fn main() -> Result<(), OrthoError> {
     // Load configuration from CLI, environment, and config files. Future

--- a/src/bin/lagc.rs
+++ b/src/bin/lagc.rs
@@ -1,9 +1,13 @@
-use lag_complexity::cli::LagcArgs;
-use ortho_config::{OrthoConfig, OrthoError};
+//! CLI entrypoint for `lagc`. Loads configuration from CLI flags,
+//! environment variables (prefix `LAGC`), and optional config files via
+//! `ortho_config`.
 
-fn main() -> Result<(), OrthoError> {
+use eyre::Result;
+use lag_complexity::cli::LagcArgs;
+
+fn main() -> Result<()> {
     // Load configuration from CLI, environment, and config files. Future
     // subcommands will branch from these parsed arguments.
-    let _cfg = LagcArgs::load()?;
+    let _cfg = <LagcArgs as ortho_config::OrthoConfig>::load()?;
     Ok(())
 }

--- a/src/bin/lagc.rs
+++ b/src/bin/lagc.rs
@@ -1,0 +1,13 @@
+use lag_complexity::cli::LagcArgs;
+use ortho_config::{OrthoConfig, OrthoError};
+
+#[expect(
+    clippy::result_large_err,
+    reason = "OrthoError originates from external crate and is acceptable here",
+)]
+fn main() -> Result<(), OrthoError> {
+    // Load configuration from CLI, environment, and config files. Future
+    // subcommands will branch from these parsed arguments.
+    let _cfg = LagcArgs::load()?;
+    Ok(())
+}

--- a/src/bin/lagc.rs
+++ b/src/bin/lagc.rs
@@ -8,6 +8,12 @@ use lag_complexity::cli::LagcArgs;
 fn main() -> Result<()> {
     // Load configuration from CLI, environment, and config files. Future
     // subcommands will branch from these parsed arguments.
-    let _cfg = <LagcArgs as ortho_config::OrthoConfig>::load()?;
+    let _cfg = <LagcArgs as ortho_config::OrthoConfig>::load().map_err(|e| {
+        if e.to_string().contains("invalid value") {
+            eyre::eyre!("invalid boolean: {e}")
+        } else {
+            e.into()
+        }
+    })?;
     Ok(())
 }

--- a/src/bin/lagc.rs
+++ b/src/bin/lagc.rs
@@ -1,10 +1,6 @@
 use lag_complexity::cli::LagcArgs;
 use ortho_config::{OrthoConfig, OrthoError};
 
-#[expect(
-    clippy::result_large_err,
-    reason = "OrthoError originates from external crate and is acceptable here"
-)]
 fn main() -> Result<(), OrthoError> {
     // Load configuration from CLI, environment, and config files. Future
     // subcommands will branch from these parsed arguments.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4,7 +4,7 @@
 
 use figment::{
     Figment,
-    providers::{Env, Format, Json, Toml, Yaml},
+    providers::{Env, Json, Toml, Yaml},
 };
 use ortho_config::OrthoError;
 use serde::Deserialize;
@@ -74,7 +74,7 @@ impl LagcArgs {
     /// Returns an [`OrthoError`] if the file cannot be read or parsed as TOML.
     pub fn load_from_config(path: &str) -> Result<Self, OrthoError> {
         Figment::new()
-            .merge(Toml::file(path))
+            .merge(<Toml as figment::providers::Format>::file(path))
             .extract()
             .map_err(Into::into)
     }
@@ -94,9 +94,11 @@ impl LagcArgs {
             .and_then(|e| e.to_str())
             .map(str::to_ascii_lowercase);
         let figment = match ext.as_deref() {
-            Some("yaml" | "yml") => Figment::new().merge(Yaml::file(path)),
-            Some("json") => Figment::new().merge(Json::file(path)),
-            _ => Figment::new().merge(Toml::file(path)),
+            Some("yaml" | "yml") => {
+                Figment::new().merge(<Yaml as figment::providers::Format>::file(path))
+            }
+            Some("json") => Figment::new().merge(<Json as figment::providers::Format>::file(path)),
+            _ => Figment::new().merge(<Toml as figment::providers::Format>::file(path)),
         };
         figment.extract().map_err(Into::into)
     }
@@ -109,7 +111,7 @@ impl LagcArgs {
     /// Environment takes precedence over file values.
     pub fn load_from_env_and_config(path: &str) -> Result<Self, OrthoError> {
         Figment::new()
-            .merge(Toml::file(path))
+            .merge(<Toml as figment::providers::Format>::file(path))
             .merge(Env::prefixed("LAGC_"))
             .extract()
             .map_err(Into::into)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,26 @@
+use ortho_config::OrthoConfig;
+use serde::Deserialize;
+
+/// Command-line arguments for the `lagc` binary.
+///
+/// This structure is intentionally minimal; it will grow alongside the
+/// application's capabilities. Configuration values are loaded from command
+/// line arguments, environment variables (prefixed with `LAGC_`), and an
+/// optional configuration file.
+///
+/// # Examples
+///
+/// ```
+/// use lag_complexity::cli::LagcArgs;
+/// use ortho_config::OrthoConfig;
+///
+/// let args = LagcArgs::load_from_iter(["lagc", "--dry-run"]).unwrap();
+/// assert!(args.dry_run);
+/// ```
+#[derive(Debug, Deserialize, OrthoConfig)]
+#[ortho_config(prefix = "LAGC")]
+pub struct LagcArgs {
+    /// Run without performing any side effects.
+    #[ortho_config(default = false)]
+    pub dry_run: bool,
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -23,7 +23,7 @@ use std::{env, path::PathBuf};
 /// use lag_complexity::cli::LagcArgs;
 /// use ortho_config::OrthoConfig;
 ///
-/// let args = LagcArgs::load_from_iter(["lagc", "--dry-run"])
+/// let args = LagcArgs::load_from_iter(["lagc", "--dry-run=true"])
 ///     .expect("load args from CLI iterator");
 /// assert!(args.dry_run);
 /// ```

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,10 +1,14 @@
+//! CLI argument types and layered configuration for the `lagc` binary.
+//! Loads from CLI args, environment (prefix `LAGC_`), and optional config
+//! files.
+
 use figment::{
     Error as FigmentError, Figment,
     providers::{Format, Toml},
 };
-use ortho_config::{OrthoConfig, OrthoError};
+use ortho_config::OrthoError;
 use serde::Deserialize;
-use std::env;
+use std::{env, path::PathBuf};
 
 /// Command-line arguments for the `lagc` binary.
 ///
@@ -19,15 +23,21 @@ use std::env;
 /// use lag_complexity::cli::LagcArgs;
 /// use ortho_config::OrthoConfig;
 ///
-/// let args = LagcArgs::load_from_iter(["lagc", "--dry-run"]).unwrap();
+/// let args = LagcArgs::load_from_iter(["lagc", "--dry-run"])
+///     .expect("load args from CLI iterator");
 /// assert!(args.dry_run);
 /// ```
-#[derive(Debug, Deserialize, OrthoConfig)]
+#[derive(Debug, Deserialize, ortho_config::OrthoConfig)]
 #[ortho_config(prefix = "LAGC")]
 pub struct LagcArgs {
     /// Run without performing any side effects.
     #[ortho_config(default = false)]
+    #[serde(default)]
     pub dry_run: bool,
+
+    /// Optional path to a configuration file.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub config_path: Option<PathBuf>,
 }
 
 impl LagcArgs {
@@ -42,9 +52,15 @@ impl LagcArgs {
                 let dry_run = v
                     .parse::<bool>()
                     .map_err(|e| OrthoError::gathering(FigmentError::from(e.to_string())))?;
-                Ok(Self { dry_run })
+                Ok(Self {
+                    dry_run,
+                    config_path: None,
+                })
             }
-            Err(env::VarError::NotPresent) => Ok(Self { dry_run: false }),
+            Err(env::VarError::NotPresent) => Ok(Self {
+                dry_run: false,
+                config_path: None,
+            }),
             Err(e) => Err(OrthoError::gathering(FigmentError::from(e.to_string()))),
         }
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -103,11 +103,10 @@ impl LagcArgs {
 
     /// Load configuration from environment variables and a TOML file path.
     ///
-    /// Environment values take precedence over the file.
-    ///
     /// # Errors
     ///
     /// Returns an [`OrthoError`] if either source contains invalid values.
+    /// Environment takes precedence over file values.
     pub fn load_from_env_and_config(path: &str) -> Result<Self, OrthoError> {
         Figment::new()
             .merge(Toml::file(path))

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -29,18 +29,15 @@ use std::path::PathBuf;
 /// assert!(args.dry_run);
 /// ```
 ///
-/// Load from a configuration file:
+/// # Loading from a TOML file
+///
 /// ```
 /// use lag_complexity::cli::LagcArgs;
 /// use ortho_config::OrthoConfig;
-/// use std::io::Write;
-/// use tempfile::NamedTempFile;
 ///
-/// let mut file = NamedTempFile::new().expect("create temp file");
-/// writeln!(file, "dry_run = true").expect("write config");
-/// let path = file.path().to_str().expect("path str");
-/// let args = LagcArgs::load_from_iter(["lagc", "--config-path", path])
-///     .expect("load args from config path");
+/// // With a config.toml file containing: dry_run = true
+/// let args = LagcArgs::load_from_config("config.toml")
+///     .expect("load args from TOML file");
 /// assert!(args.dry_run);
 /// ```
 #[derive(Debug, Deserialize, ortho_config::OrthoConfig)]
@@ -53,6 +50,7 @@ pub struct LagcArgs {
 
     /// Optional path to a configuration file.
     #[serde(skip)]
+    #[ortho_config(cli_long = "config-path")]
     pub config_path: Option<PathBuf>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,12 +2,14 @@
 //! Re-exports public types and traits.
 
 pub mod api;
+pub mod cli;
 pub mod config;
 pub mod providers;
 pub mod sigma;
 pub mod variance;
 
 pub use api::{Complexity, ComplexityFn, Trace};
+pub use cli::LagcArgs;
 pub use config::{ScopingConfig, VarianceScopingConfig};
 pub use providers::{AmbiguityEstimator, DepthEstimator, EmbeddingProvider, TextProcessor};
 pub use sigma::Sigma;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 //! Re-exports public types and traits.
 
 pub mod api;
+#[cfg(feature = "cli")]
 pub mod cli;
 pub mod config;
 pub mod providers;
@@ -9,6 +10,7 @@ pub mod sigma;
 pub mod variance;
 
 pub use api::{Complexity, ComplexityFn, Trace};
+#[cfg(feature = "cli")]
 pub use cli::LagcArgs;
 pub use config::{ScopingConfig, VarianceScopingConfig};
 pub use providers::{AmbiguityEstimator, DepthEstimator, EmbeddingProvider, TextProcessor};

--- a/tests/features/lagc_cli.feature
+++ b/tests/features/lagc_cli.feature
@@ -5,14 +5,19 @@ Feature: lagc CLI stub
     When running with "--dry-run=true"
     Then it exits successfully
 
+  Scenario: run with dry-run disabled explicitly
+    Given the lagc binary
+    When running with "--dry-run=false"
+    Then it exits successfully
+
+  Scenario: run with dry-run from environment
+    Given the lagc binary
+    And env "LAGC_DRY_RUN=true"
+    When running with no args
+    Then it exits successfully
+
   Scenario: run with invalid flag value
     Given the lagc binary
     When running with "--dry-run=maybe"
     Then it exits with an error
-
-  Scenario: run in dry-run mode via environment variable
-    Given the lagc binary
-    And these environment variables
-      | LAGC_DRY_RUN | true |
-    When running with no args
-    Then it exits successfully
+    And stderr contains "invalid value"

--- a/tests/features/lagc_cli.feature
+++ b/tests/features/lagc_cli.feature
@@ -9,3 +9,10 @@ Feature: lagc CLI stub
     Given the lagc binary
     When running with "--dry-run=maybe"
     Then it exits with an error
+
+  Scenario: run in dry-run mode via environment variable
+    Given the lagc binary
+    And these environment variables
+      | LAGC_DRY_RUN | true |
+    When running with no args
+    Then it exits successfully

--- a/tests/features/lagc_cli.feature
+++ b/tests/features/lagc_cli.feature
@@ -20,4 +20,4 @@ Feature: lagc CLI stub
     Given the lagc binary
     When running with "--dry-run=maybe"
     Then it exits with an error
-    And stderr contains "invalid value"
+    And stderr contains "invalid boolean"

--- a/tests/features/lagc_cli.feature
+++ b/tests/features/lagc_cli.feature
@@ -1,0 +1,11 @@
+Feature: lagc CLI stub
+
+  Scenario: run in dry-run mode
+    Given the lagc binary
+    When running with "--dry-run=true"
+    Then it exits successfully
+
+  Scenario: run with invalid flag value
+    Given the lagc binary
+    When running with "--dry-run=maybe"
+    Then it exits with an error

--- a/tests/lagc_args.rs
+++ b/tests/lagc_args.rs
@@ -1,0 +1,18 @@
+use lag_complexity::cli::LagcArgs;
+use ortho_config::OrthoConfig;
+use rstest::rstest;
+
+#[rstest]
+#[case(vec!["lagc"], false)]
+#[case(vec!["lagc", "--dry-run=true"], true)]
+fn load_parses_dry_run(#[case] argv: Vec<&str>, #[case] expected: bool) {
+    let cfg = LagcArgs::load_from_iter(argv)
+        .unwrap_or_else(|e| panic!("unexpected parse error: {e}"));
+    assert_eq!(cfg.dry_run, expected);
+}
+
+#[rstest]
+fn load_rejects_invalid_bool() {
+    let result = LagcArgs::load_from_iter(vec!["lagc", "--dry-run=maybe"]);
+    assert!(result.is_err());
+}

--- a/tests/lagc_args.rs
+++ b/tests/lagc_args.rs
@@ -6,8 +6,8 @@ use rstest::rstest;
 #[case(vec!["lagc"], false)]
 #[case(vec!["lagc", "--dry-run=true"], true)]
 fn load_parses_dry_run(#[case] argv: Vec<&str>, #[case] expected: bool) {
-    let cfg = LagcArgs::load_from_iter(argv)
-        .unwrap_or_else(|e| panic!("unexpected parse error: {e}"));
+    let cfg =
+        LagcArgs::load_from_iter(argv).unwrap_or_else(|e| panic!("unexpected parse error: {e}"));
     assert_eq!(cfg.dry_run, expected);
 }
 

--- a/tests/lagc_args.rs
+++ b/tests/lagc_args.rs
@@ -1,6 +1,20 @@
 use lag_complexity::cli::LagcArgs;
 use ortho_config::OrthoConfig;
 use rstest::rstest;
+use serial_test::serial;
+use std::env;
+use std::io::Write;
+use tempfile::NamedTempFile;
+
+fn set_var(key: &str, val: &str) {
+    // Safety: tests manipulate process-wide environment serially.
+    unsafe { env::set_var(key, val) };
+}
+
+fn remove_var(key: &str) {
+    // Safety: tests manipulate process-wide environment serially.
+    unsafe { env::remove_var(key) };
+}
 
 #[rstest]
 #[case(vec!["lagc"], false)]
@@ -12,7 +26,79 @@ fn load_parses_dry_run(#[case] argv: Vec<&str>, #[case] expected: bool) {
 }
 
 #[rstest]
-fn load_rejects_invalid_bool() {
-    let result = LagcArgs::load_from_iter(vec!["lagc", "--dry-run=maybe"]);
+#[case("maybe")]
+#[case("Maybe")]
+#[case("MAYBE")]
+#[case("1")]
+#[case("0")]
+#[case("yes")]
+fn load_rejects_invalid_bool(#[case] value: &str) {
+    let arg = format!("--dry-run={value}");
+    let result = LagcArgs::load_from_iter(["lagc", arg.as_str()]);
     assert!(result.is_err());
+}
+
+#[rstest]
+#[serial]
+fn env_var_parsing_sets_dry_run() {
+    set_var("LAGC_DRY_RUN", "true");
+    let cfg =
+        LagcArgs::load_from_env().unwrap_or_else(|e| panic!("unexpected env parse error: {e}"));
+    assert!(cfg.dry_run);
+    remove_var("LAGC_DRY_RUN");
+}
+
+#[rstest]
+#[serial]
+fn env_var_parsing_invalid_bool() {
+    set_var("LAGC_DRY_RUN", "notabool");
+    let result = LagcArgs::load_from_env();
+    assert!(result.is_err());
+    remove_var("LAGC_DRY_RUN");
+}
+
+#[rstest]
+fn config_file_parsing_sets_dry_run() {
+    let mut file = NamedTempFile::new().unwrap_or_else(|e| panic!("create temp file: {e}"));
+    writeln!(file, "dry_run = true").unwrap_or_else(|e| panic!("write config: {e}"));
+    let path = file.path().to_str().unwrap_or_else(|| panic!("path str"));
+    let cfg = LagcArgs::load_from_config(path)
+        .unwrap_or_else(|e| panic!("unexpected config parse error: {e}"));
+    assert!(cfg.dry_run);
+}
+
+#[rstest]
+fn config_file_parsing_invalid_bool() {
+    let mut file = NamedTempFile::new().unwrap_or_else(|e| panic!("create temp file: {e}"));
+    writeln!(file, "dry_run = notabool").unwrap_or_else(|e| panic!("write config: {e}"));
+    let path = file.path().to_str().unwrap_or_else(|| panic!("path str"));
+    let result = LagcArgs::load_from_config(path);
+    assert!(result.is_err());
+}
+
+#[rstest]
+#[serial]
+fn precedence_cli_over_env_and_config() {
+    set_var("LAGC_DRY_RUN", "false");
+    let mut file = NamedTempFile::new().unwrap_or_else(|e| panic!("create temp file: {e}"));
+    writeln!(file, "dry_run = false").unwrap_or_else(|e| panic!("write config: {e}"));
+    let path = file.path().to_str().unwrap_or_else(|| panic!("path str"));
+    let argv = vec!["lagc", "--dry-run=true", "--config-path", path];
+    let cfg =
+        LagcArgs::load_from_iter(argv).unwrap_or_else(|e| panic!("unexpected parse error: {e}"));
+    assert!(cfg.dry_run);
+    remove_var("LAGC_DRY_RUN");
+}
+
+#[rstest]
+#[serial]
+fn precedence_env_over_config() {
+    set_var("LAGC_DRY_RUN", "true");
+    let mut file = NamedTempFile::new().unwrap_or_else(|e| panic!("create temp file: {e}"));
+    writeln!(file, "dry_run = false").unwrap_or_else(|e| panic!("write config: {e}"));
+    let path = file.path().to_str().unwrap_or_else(|| panic!("path str"));
+    let cfg = LagcArgs::load_from_env_and_config(path)
+        .unwrap_or_else(|e| panic!("unexpected parse error: {e}"));
+    assert!(cfg.dry_run);
+    remove_var("LAGC_DRY_RUN");
 }

--- a/tests/lagc_cli_bdd.rs
+++ b/tests/lagc_cli_bdd.rs
@@ -1,14 +1,16 @@
 //! Behaviour tests for the `lagc` CLI.
 
 use assert_cmd::Command;
+use once_cell::unsync::OnceCell;
 use rstest::fixture;
 use rstest_bdd_macros::{given, scenario, then, when};
-use std::cell::RefCell;
+use std::collections::HashMap;
 use std::process::Output;
 
 #[derive(Default)]
 struct CliContext {
-    output: RefCell<Option<Output>>,
+    env: OnceCell<HashMap<String, String>>,
+    output: OnceCell<Output>,
 }
 
 #[fixture]
@@ -21,6 +23,20 @@ fn given_binary(#[from(cli_context)] ctx: &CliContext) {
     let _ = ctx;
 }
 
+#[given("these environment variables")]
+fn given_env(datatable: Vec<Vec<String>>, #[from(cli_context)] ctx: &CliContext) {
+    let map = datatable
+        .into_iter()
+        .filter_map(|row| match (row.first(), row.get(1)) {
+            (Some(k), Some(v)) => Some((k.clone(), v.clone())),
+            _ => None,
+        })
+        .collect();
+    ctx.env
+        .set(map)
+        .unwrap_or_else(|_| panic!("env already set"));
+}
+
 #[when("running with \"{args}\"")]
 #[expect(
     clippy::needless_pass_by_value,
@@ -28,26 +44,43 @@ fn given_binary(#[from(cli_context)] ctx: &CliContext) {
 )]
 #[expect(clippy::expect_used, reason = "tests should fail loudly")]
 fn when_running(args: String, #[from(cli_context)] ctx: &CliContext) {
-    let output = Command::cargo_bin("lagc")
-        .expect("failed to locate lagc binary")
-        .args(args.split_whitespace())
-        .output()
-        .expect("failed to run lagc");
-    *ctx.output.borrow_mut() = Some(output);
+    let parsed_args = shlex::split(&args)
+        .unwrap_or_else(|| args.split_whitespace().map(ToOwned::to_owned).collect());
+    let mut cmd = Command::cargo_bin("lagc").expect("failed to locate lagc binary");
+    if let Some(env) = ctx.env.get() {
+        cmd.envs(env);
+    }
+    let output = cmd.args(&parsed_args).output().expect("failed to run lagc");
+    ctx.output.set(output).expect("output already set");
+}
+
+#[when("running with no args")]
+fn when_running_empty(#[from(cli_context)] ctx: &CliContext) {
+    when_running(String::new(), ctx);
 }
 
 #[then("it exits successfully")]
 #[expect(clippy::expect_used, reason = "tests should fail loudly")]
+#[expect(clippy::print_stderr, reason = "diagnose test failures")]
 fn then_success(#[from(cli_context)] ctx: &CliContext) {
-    let status = ctx.output.borrow().as_ref().expect("missing output").status;
-    assert!(status.success());
+    let out = ctx.output.get().expect("missing output");
+    if !out.status.success() {
+        eprintln!("stdout:\n{}", String::from_utf8_lossy(&out.stdout));
+        eprintln!("stderr:\n{}", String::from_utf8_lossy(&out.stderr));
+    }
+    assert!(out.status.success());
 }
 
 #[then("it exits with an error")]
 #[expect(clippy::expect_used, reason = "tests should fail loudly")]
+#[expect(clippy::print_stderr, reason = "diagnose test failures")]
 fn then_error(#[from(cli_context)] ctx: &CliContext) {
-    let status = ctx.output.borrow().as_ref().expect("missing output").status;
-    assert!(!status.success());
+    let out = ctx.output.get().expect("missing output");
+    if out.status.success() {
+        eprintln!("stdout:\n{}", String::from_utf8_lossy(&out.stdout));
+        eprintln!("stderr:\n{}", String::from_utf8_lossy(&out.stderr));
+    }
+    assert!(!out.status.success());
 }
 
 #[scenario(path = "tests/features/lagc_cli.feature", index = 0)]
@@ -57,5 +90,10 @@ fn dry_run(cli_context: CliContext) {
 
 #[scenario(path = "tests/features/lagc_cli.feature", index = 1)]
 fn invalid_flag(cli_context: CliContext) {
+    let _ = cli_context;
+}
+
+#[scenario(path = "tests/features/lagc_cli.feature", index = 2)]
+fn env_dry_run(cli_context: CliContext) {
     let _ = cli_context;
 }

--- a/tests/lagc_cli_bdd.rs
+++ b/tests/lagc_cli_bdd.rs
@@ -1,9 +1,9 @@
 //! Behaviour tests for the `lagc` CLI.
 
+use assert_cmd::Command;
 use rstest::fixture;
 use rstest_bdd_macros::{given, scenario, then, when};
 use std::cell::RefCell;
-use assert_cmd::Command;
 use std::process::Output;
 
 #[derive(Default)]
@@ -17,7 +17,9 @@ fn cli_context() -> CliContext {
 }
 
 #[given("the lagc binary")]
-fn given_binary(#[from(cli_context)] ctx: &CliContext) { let _ = ctx; }
+fn given_binary(#[from(cli_context)] ctx: &CliContext) {
+    let _ = ctx;
+}
 
 #[when("running with \"{args}\"")]
 #[expect(
@@ -27,7 +29,7 @@ fn given_binary(#[from(cli_context)] ctx: &CliContext) { let _ = ctx; }
 #[expect(clippy::expect_used, reason = "tests should fail loudly")]
 fn when_running(args: String, #[from(cli_context)] ctx: &CliContext) {
     let output = Command::cargo_bin("lagc")
-        .unwrap_or_else(|e| panic!("failed to locate lagc binary: {e}"))
+        .expect("failed to locate lagc binary")
         .args(args.split_whitespace())
         .output()
         .expect("failed to run lagc");
@@ -49,7 +51,11 @@ fn then_error(#[from(cli_context)] ctx: &CliContext) {
 }
 
 #[scenario(path = "tests/features/lagc_cli.feature", index = 0)]
-fn dry_run(cli_context: CliContext) { let _ = cli_context; }
+fn dry_run(cli_context: CliContext) {
+    let _ = cli_context;
+}
 
 #[scenario(path = "tests/features/lagc_cli.feature", index = 1)]
-fn invalid_flag(cli_context: CliContext) { let _ = cli_context; }
+fn invalid_flag(cli_context: CliContext) {
+    let _ = cli_context;
+}

--- a/tests/lagc_cli_bdd.rs
+++ b/tests/lagc_cli_bdd.rs
@@ -112,12 +112,12 @@ fn then_stderr_contains(text: String, #[from(cli_context)] ctx: &CliContext) {
     clippy::needless_pass_by_value,
     reason = "BDD macro injects owned value"
 )]
-#[expect(clippy::print_stderr, reason = "diagnose test failures")]
+#[expect(clippy::print_stdout, reason = "diagnose test failures")]
 fn then_stdout_contains(text: String, #[from(cli_context)] ctx: &CliContext) {
     let out = ctx.output.get().expect("missing output");
     let stdout = String::from_utf8_lossy(&out.stdout);
     if !stdout.contains(&text) {
-        eprintln!("stdout:\n{stdout}");
+        println!("stdout:\n{stdout}");
     }
     assert!(stdout.contains(&text));
 }

--- a/tests/lagc_cli_bdd.rs
+++ b/tests/lagc_cli_bdd.rs
@@ -1,0 +1,55 @@
+//! Behaviour tests for the `lagc` CLI.
+
+use rstest::fixture;
+use rstest_bdd_macros::{given, scenario, then, when};
+use std::cell::RefCell;
+use assert_cmd::Command;
+use std::process::Output;
+
+#[derive(Default)]
+struct CliContext {
+    output: RefCell<Option<Output>>,
+}
+
+#[fixture]
+fn cli_context() -> CliContext {
+    CliContext::default()
+}
+
+#[given("the lagc binary")]
+fn given_binary(#[from(cli_context)] ctx: &CliContext) { let _ = ctx; }
+
+#[when("running with \"{args}\"")]
+#[expect(
+    clippy::needless_pass_by_value,
+    reason = "BDD macro injects owned value"
+)]
+#[expect(clippy::expect_used, reason = "tests should fail loudly")]
+fn when_running(args: String, #[from(cli_context)] ctx: &CliContext) {
+    let output = Command::cargo_bin("lagc")
+        .unwrap_or_else(|e| panic!("failed to locate lagc binary: {e}"))
+        .args(args.split_whitespace())
+        .output()
+        .expect("failed to run lagc");
+    *ctx.output.borrow_mut() = Some(output);
+}
+
+#[then("it exits successfully")]
+#[expect(clippy::expect_used, reason = "tests should fail loudly")]
+fn then_success(#[from(cli_context)] ctx: &CliContext) {
+    let status = ctx.output.borrow().as_ref().expect("missing output").status;
+    assert!(status.success());
+}
+
+#[then("it exits with an error")]
+#[expect(clippy::expect_used, reason = "tests should fail loudly")]
+fn then_error(#[from(cli_context)] ctx: &CliContext) {
+    let status = ctx.output.borrow().as_ref().expect("missing output").status;
+    assert!(!status.success());
+}
+
+#[scenario(path = "tests/features/lagc_cli.feature", index = 0)]
+fn dry_run(cli_context: CliContext) { let _ = cli_context; }
+
+#[scenario(path = "tests/features/lagc_cli.feature", index = 1)]
+fn invalid_flag(cli_context: CliContext) { let _ = cli_context; }

--- a/tests/lagc_cli_bdd.rs
+++ b/tests/lagc_cli_bdd.rs
@@ -102,6 +102,14 @@ fn then_error(#[from(cli_context)] ctx: &CliContext) {
     assert!(!out.status.success());
 }
 
+#[then("it exits with code {code}")]
+#[expect(clippy::expect_used, reason = "tests should fail loudly")]
+fn then_exit_code(code: i32, #[from(cli_context)] ctx: &CliContext) {
+    let out = ctx.output.get().expect("missing output");
+    dump_on(out.status.code() == Some(code), out);
+    assert_eq!(out.status.code(), Some(code));
+}
+
 #[then("stderr contains \"{text}\"")]
 #[expect(clippy::expect_used, reason = "tests should fail loudly")]
 #[expect(


### PR DESCRIPTION
## Summary
- add `lagc` CLI skeleton backed by ortho-config
- cover flag parsing with unit tests and BDD scenarios
- mark roadmap CLI task complete and document design choice

## Testing
- `make fmt`
- `make check-fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_68a99824e2548322ac7e0355dd9537be

## Summary by Sourcery

Scaffold the lagc CLI using ortho-config for unified argument, environment, and file configuration, introduce a dry-run flag, add a binary stub, update docs and dependencies, and cover the new CLI behavior with unit and BDD tests.

New Features:
- Add cli module with LagcArgs derived from OrthoConfig to parse flags, environment variables, and config files.
- Introduce lagc binary stub that loads configuration and exits successfully.

Build:
- Add ortho-config, clap, figment, and supporting crates to Cargo.toml and configure JSON5, YAML, and TOML feature flags.

Documentation:
- Update design and roadmap documentation to use ortho-config instead of clap and mark the CLI stub as complete.

Tests:
- Add unit tests for LagcArgs flag parsing.
- Add BDD scenarios and feature file to validate dry-run mode and error handling for invalid flags.