### PR TITLE
Add ADR for DepthClassifierOnnx and update design documentation

### DIFF
--- a/docs/adr-depth-classifier-onnx.md
+++ b/docs/adr-depth-classifier-onnx.md
@@ -106,8 +106,9 @@ MLP** as a supported fallback under a feature flag.
 ### Graph notes
 
 - Opset: 17.  
-- Graph includes tokenization-independent components only; tokenization
-  performed in Rust using a deterministic vocabulary (e.g., `tokenizers`).
+- Graph keeps tokenization-independent components only. Rust performs the
+  tokenization with a deterministic `tokenizers` vocabulary so every
+  environment receives identical inputs.
 - Optional calibration added as `Mul`/`Add` after the ordinal expectation;
   otherwise applied in Rust before Sigma.
 
@@ -166,8 +167,8 @@ MLP** as a supported fallback under a feature flag.
   }`.
 - **Trait:** implements `TextProcessor<Output = f32>`; returns scalar raw depth
   (expected steps or mapped mid-bin).
-- **Tokenization:** performed in Rust with a pinned vocabulary; deterministic
-  and locale-safe.
+- **Tokenization:** handled in Rust with a pinned vocabulary, keeping the
+  pipeline deterministic and locale-safe.
 - **Runtime pinning:** the `ort` crate is fixed to the `2.0.x` series (bundling
   ONNX Runtime 1.22, which supports the opset 17 graph), ensuring the shipped
   runtime matches the opset required by the artefacts.

--- a/docs/complexity-antipatterns-and-refactoring-strategies.md
+++ b/docs/complexity-antipatterns-and-refactoring-strategies.md
@@ -418,7 +418,7 @@ CQRS is an architectural pattern that segregates operations that modify state
 and should represent specific business intentions (e.g.,
 
 `BookHotelRoomCommand` rather than `SetReservationStatusCommand`).18 Queries
-never alter data and return Data Transfer Objects (DTOs) optimised for display
+never alter data and return Data Transfer Objects (DTOs) optimized for display
 needs.18
 
 While CQRS operates at a higher architectural level than a single Bumpy Road

--- a/docs/lag-complexity-function-design.md
+++ b/docs/lag-complexity-function-design.md
@@ -587,12 +587,12 @@ production-oriented, industrial-grade system.
 
 #### Table 2: provider implementation trade-offs (depth & ambiguity)
 
-| Provider Type                | Accuracy | Latency         | Cost (Compute/API) | Dependencies                | Use Case                                                                 |
-| ---------------------------- | -------- | --------------- | ------------------ | --------------------------- | ------------------------------------------------------------------------ |
-| **Heuristic**                | Low      | Very Low (<1ms) | Negligible         | None                        | Default, low-latency applications, initial signal.                       |
-| **ONNX Transformer-Ordinal** | High     | Low (~5-10ms)   | Low (local CPU)    | `ort` crate, model file     | Production default with deterministic CPU inference and Sigma alignment. |
-| **ONNX MLP Fallback**        | Medium   | Very Low (~2ms) | Low (local CPU)    | `ort` crate, model file     | Tokenization-constrained deployments needing resilience.                 |
-| **External LLM**             | High     | High (500ms+)   | High               | `reqwest`, `tokio`, API key | Systems where accuracy is paramount and latency/cost are acceptable.     |
+| Provider Type                | Accuracy | Latency         | Cost (Compute/API) | Dependencies                | Use Case                                                    |
+| ---------------------------- | -------- | --------------- | ------------------ | --------------------------- | ----------------------------------------------------------- |
+| **Heuristic**                | Low      | Very Low (<1ms) | Negligible         | None                        | Default for low-latency deployments; initial signal.        |
+| **ONNX Transformer-Ordinal** | High     | Low (~5-10ms)   | Low (local CPU)    | `ort` crate, model file     | Production default offering deterministic CPU inference.    |
+| **ONNX MLP Fallback**        | Medium   | Very Low (~2ms) | Low (local CPU)    | `ort` crate, model file     | Tokenization-constrained deployments needing resilience.    |
+| **External LLM**             | High     | High (500ms+)   | High               | `reqwest`, `tokio`, API key | Maximum accuracy when higher latency or cost is acceptable. |
 
 ## 3. Configuration deep dive: normalization, scheduling, and halting
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -11,13 +11,13 @@ primary public interfaces.
 - [x] Define all public traits (`ComplexityFn`, `EmbeddingProvider`,
     `DepthEstimator`, `AmbiguityEstimator`).
 - [x] Implement the mathematical logic for variance calculation and all `Sigma`
-  normalisation strategies.
+  normalization strategies.
 - [x] Create the stub for the `lagc` CLI binary using `ortho_config`
   (published as `ortho-config` on crates.io) [^hyphen-underscore].
 - [ ] **Acceptance Criteria**: The crate and all its core types compile
   successfully.
 - [x] **Acceptance Criteria**: A comprehensive suite of unit tests for the
-  mathematical and normalisation logic passes.
+  mathematical and normalization logic passes.
 - [x] **Acceptance Criteria**: The `lagc` CLI application can be built and run
   (verify with: `cargo run --bin lagc -- --help`), though it will have no
   functional commands yet.
@@ -40,7 +40,7 @@ relying on fast, lightweight heuristics.
 ## Phase 2 — Model-Backed Providers & Performance (Duration: 2 weeks)
 
 This phase focuses on enhancing accuracy with model-based providers and
-optimising for performance.
+optimizing for performance.
 
 - [ ] Train or adapt and export the initial ONNX models for depth and ambiguity
   classification.
@@ -67,13 +67,13 @@ and tuning its parameters.
 - [ ] Implement the calculation of correlation (`Kendall-τ`, `Spearman-ρ`) and
   calibration (`ECE`) metrics.
 - [ ] Run the evaluation harness and analyse the results to fine-tune the
-  `Sigma` normalisation parameters and the weights within the heuristic models.
+  `Sigma` normalization parameters and the weights within the heuristic models.
 - [ ] **Acceptance Criteria**: The evaluation harness successfully generates a
   report (`EVALUATION.md`).
 - [ ] **Acceptance Criteria**: The report demonstrates a statistically
   significant positive correlation between the crate's component scores and the
   corresponding dataset labels.
-- [ ] **Acceptance Criteria**: The calibrated parameters are finalised and
+- [ ] **Acceptance Criteria**: The calibrated parameters are finalized and
   committed as the default configuration.
 
 ## Phase 4 — Bindings & Demos (Duration: 2 weeks)
@@ -103,7 +103,7 @@ observable production deployment.
 - [ ] Implement the `with_redaction_hook` method for PII scrubbing.
 - [ ] Write comprehensive `rustdoc` documentation for all public APIs,
   including detailed usage examples.
-- [ ] Finalise the `README.md` to include installation instructions, usage
+- [ ] Finalize the `README.md` to include installation instructions, usage
   examples, and links to benchmarks and evaluation reports.
 - [ ] **Acceptance Criteria**: The crate is fully documented, with
   `cargo doc --open` producing a complete and navigable API reference.


### PR DESCRIPTION
## Summary
- document the accepted Transformer-ordinal architecture for DepthClassifierOnnx, including optimisation roadmap, fallbacks, and rollout plan
- align the design document with the new depth estimator plan, covering heuristic headings, ONNX provider details, caching guidance, and dataset evaluation updates

## Testing
- make fmt
- make markdownlint

------
https://chatgpt.com/codex/tasks/task_e_68d5660e18ac8322b9f169d92d63b37c

## Summary by Sourcery

Introduce an ADR for the DepthClassifierOnnx decision and align the complexity function design document with the selected Transformer-ordinal depth estimator, including provider table updates, fallback options, caching guidance, and dataset evaluation improvements.

Enhancements:
- Document the DepthClassifierOnnx architecture and rollout plan in a new ADR
- Embed detailed ONNX depth estimator and MLP fallback information into the complexity design doc

Documentation:
- Add ADR for DepthClassifierOnnx decision record
- Refine feature engineering sections for depth and ambiguity
- Update provider trade-offs table with ONNX Transformer-Ordinal and MLP fallback entries
- Clarify caching strategy, parallelism patterns, and dataset evaluation links