### PR TITLE
Implement regex-based ambiguous entity detection

### DIFF
--- a/docs/lag-complexity-function-design.md
+++ b/docs/lag-complexity-function-design.md
@@ -545,14 +545,21 @@ English text.[^10]
   single pseudo-entropy value. Laplace smoothing will be applied to ensure a
   stable, non-zero score even for queries with no detected ambiguity signals.
 - **Implementation note:** The heuristic uses a shared normaliser for token
-  casing and punctuation. Ambiguous entity matching applies conservative
-  singularization (shared text utils) and uses `regex` word boundaries to avoid
-  partial matches. Pronouns and vague terms carry unit weight, ambiguous
-  entities count double, and Laplace smoothing adds one to the total. The
-  antecedent check splits the input into sentences, looks for capitalized
-  tokens and definite noun phrases in the current or previous sentence, and
-  only applies the unresolved-pronoun bonus when no candidate is present. Full
-  resolution remains deferred to model-based providers.
+  casing and punctuation. Ambiguous entity matching now relies on precompiled
+  word-boundary regexes rather than token-level singularisation, keeping
+  pronoun and vague term weighting unchanged. Ambiguous entities still count
+  double and Laplace smoothing adds one to the total. The antecedent check
+  splits the input into sentences, looks for capitalized tokens and definite
+  noun phrases in the current or previous sentence, and only applies the
+  unresolved-pronoun bonus when no candidate is present. Full resolution
+  remains deferred to model-based providers.
+
+Implementation update (heuristic baseline): The shipped implementation now
+precompiles a curated lexicon of ambiguous entities—Amazon, Apple, Delta,
+Jaguar, Jordan, Mercury, Nile, Orion, Python, and Saturn—into case-insensitive,
+word-boundary regex patterns. This pre-pass runs before token normalisation so
+capitalised, hyphenated, and punctuated mentions are captured, satisfying the
+design requirement for an NER/regex sweep.
 
 #### Model-backed option (AmbiguityClassifierOnnx)
 

--- a/docs/lag-complexity-function-design.md
+++ b/docs/lag-complexity-function-design.md
@@ -544,9 +544,9 @@ English text.[^10]
 - **Aggregation:** The scores from these risk factors will be combined into a
   single pseudo-entropy value. Laplace smoothing will be applied to ensure a
   stable, non-zero score even for queries with no detected ambiguity signals.
-- **Implementation note:** The heuristic uses a shared normaliser for token
+- **Implementation note:** The heuristic uses a shared normalizer for token
   casing and punctuation. Ambiguous entity matching now relies on precompiled
-  word-boundary regexes rather than token-level singularisation, keeping
+  word-boundary regexes rather than token-level singularization, keeping
   pronoun and vague term weighting unchanged. Ambiguous entities still count
   double and Laplace smoothing adds one to the total. The antecedent check
   splits the input into sentences, looks for capitalized tokens and definite
@@ -557,9 +557,10 @@ English text.[^10]
 Implementation update (heuristic baseline): The shipped implementation now
 precompiles a curated lexicon of ambiguous entities—Amazon, Apple, Delta,
 Jaguar, Jordan, Mercury, Nile, Orion, Python, and Saturn—into case-insensitive,
-word-boundary regex patterns. This pre-pass runs before token normalisation so
-capitalised, hyphenated, and punctuated mentions are captured, satisfying the
-design requirement for an NER/regex sweep.
+word-boundary regex patterns. This pre-pass runs before token normalization so
+capitalized, hyphenated, and punctuated mentions are captured, satisfying the
+design requirement for an NER/regex sweep. The alternation compiles into a
+single regex so the scan only traverses the text once.
 
 #### Model-backed option (AmbiguityClassifierOnnx)
 

--- a/docs/lag-complexity-function-design.md
+++ b/docs/lag-complexity-function-design.md
@@ -554,6 +554,8 @@ English text.[^10]
   unresolved-pronoun bonus when no candidate is present. Full resolution
   remains deferred to model-based providers.
 
+<!-- mdformat off -->
+
 Implementation update (heuristic baseline): The shipped implementation now
 precompiles a curated lexicon of ambiguous entities—Amazon, Apple, Delta,
 Jaguar, Jordan, Mercury, Nile, Orion, Python, and Saturn—into case-insensitive,
@@ -561,6 +563,8 @@ word-boundary regex patterns. This pre-pass runs before token normalization so
 capitalized, hyphenated, and punctuated mentions are captured, satisfying the
 design requirement for an NER/regex sweep. The alternation compiles into a
 single regex so the scan only traverses the text once.
+
+<!-- mdformat on -->
 
 #### Model-backed option (AmbiguityClassifierOnnx)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -29,8 +29,9 @@ relying on fast, lightweight heuristics.
 
 - [x] Implement the `DepthHeuristic` and `AmbiguityHeuristic` providers.
 - [x] Add antecedent-aware pronoun weighting to the ambiguity heuristic.
-- [x] Add the regex-based ambiguous entity pre-pass for the heuristic
-  lexicon.
+- [x] Add the case-insensitive, word-boundary regex pre-pass for the curated
+  ambiguous entity lexicon (see `docs/lag-complexity-function-design.md` and PR
+  [#41](https://github.com/leynos/lag-complexity/pull/41)).
 - [x] Implement the `ApiEmbedding` provider, guarded by the `provider-api`
   feature flag.
 - [x] Create the golden-file integration test suite with an initial set of

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -29,7 +29,8 @@ relying on fast, lightweight heuristics.
 
 - [x] Implement the `DepthHeuristic` and `AmbiguityHeuristic` providers.
 - [x] Add antecedent-aware pronoun weighting to the ambiguity heuristic.
-- [x] Add the regex-based ambiguous entity pre-pass for the heuristic lexicon.
+- [x] Add the regex-based ambiguous entity pre-pass for the heuristic
+  lexicon.
 - [x] Implement the `ApiEmbedding` provider, guarded by the `provider-api`
   feature flag.
 - [x] Create the golden-file integration test suite with an initial set of

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -29,6 +29,7 @@ relying on fast, lightweight heuristics.
 
 - [x] Implement the `DepthHeuristic` and `AmbiguityHeuristic` providers.
 - [x] Add antecedent-aware pronoun weighting to the ambiguity heuristic.
+- [x] Add the regex-based ambiguous entity pre-pass for the heuristic lexicon.
 - [x] Implement the `ApiEmbedding` provider, guarded by the `provider-api`
   feature flag.
 - [x] Create the golden-file integration test suite with an initial set of

--- a/src/heuristics/ambiguity.rs
+++ b/src/heuristics/ambiguity.rs
@@ -80,7 +80,7 @@ const AMBIGUOUS_ENTITY_WEIGHT: u32 = 2;
 /// the compiled pattern runs in a single pass.
 const AMBIGUOUS_ENTITY_PATTERN: &str = concat!(
     r"(?i)\b(?:",
-    "mercur(?:y|ies)(?:'s)?",
+    "mercur(?:y|ies)(?:'s|s)?",
     "|apple(?:'s|s)?",
     "|jaguar(?:'s|s)?",
     "|python(?:'s|s)?",
@@ -141,10 +141,9 @@ mod tests {
     }
 
     #[rstest]
-    #[case("Mercury.", 3.0)]
-    #[case("Mercury-based alloys", 3.0)]
-    #[case("Discuss Python's syntax.", 3.0)]
-    #[case("Amazon, Nile, and Jordan", 7.0)]
+    #[case("Mercuries' orbit.", 3.0)]
+    #[case("Python-powered scripting.", 3.0)]
+    #[case("Amazon; Nile; Jordan; Orion.", 9.0)]
     fn recognises_ambiguous_entities(#[case] query: &str, #[case] expected: f32) {
         let h = AmbiguityHeuristic;
         assert_eq!(h.process(query), Ok(expected));

--- a/src/heuristics/text.rs
+++ b/src/heuristics/text.rs
@@ -5,7 +5,6 @@
 //! small and focused on scoring logic.
 
 use regex::Regex;
-use std::borrow::Cow;
 use std::collections::HashSet;
 
 /// Split text into lowercase tokens stripped of surrounding punctuation.
@@ -124,36 +123,6 @@ pub(crate) fn substring_count(haystack: &str, needle: &str) -> u32 {
     substring_count_regex(haystack, &re)
 }
 
-/// Naïvely singularise an English token.
-///
-/// Avoids stripping \"s\" from short words like \"this\".
-///
-/// # Examples
-///
-/// ```rust
-/// use lag_complexity::heuristics::text::singularise;
-///
-/// assert_eq!(singularise("jaguars"), "jaguar");
-/// assert_eq!(singularise("this"), "this");
-/// ```
-#[must_use]
-pub fn singularise(token: &str) -> Cow<'_, str> {
-    if should_singularise(token) {
-        Cow::Owned(token.strip_suffix('s').unwrap_or(token).to_string())
-    } else {
-        Cow::Borrowed(token)
-    }
-}
-
-/// Determine whether `singularise` should strip a trailing "s".
-///
-/// This guards against short tokens and a few explicit exceptions where the
-/// final "s" is meaningful.
-fn should_singularise(token: &str) -> bool {
-    const EXCEPTIONS: &[&str] = &["this", "his", "is"];
-    token.len() > 3 && token.ends_with('s') && !EXCEPTIONS.contains(&token)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -203,12 +172,6 @@ mod tests {
         assert_eq!(substring_count("smores", "more"), 0);
         assert_eq!(substring_count("aaaa", "aa"), 0);
         assert_eq!(substring_count("hay", ""), 0);
-    }
-
-    #[test]
-    fn singularises_tokens() {
-        assert_eq!(singularise("jaguars"), "jaguar");
-        assert_eq!(singularise("this"), "this");
     }
 
     #[test]

--- a/tests/ambiguity_heuristic.proptest-regressions
+++ b/tests/ambiguity_heuristic.proptest-regressions
@@ -1,0 +1,6 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.

--- a/tests/ambiguity_heuristic.rs
+++ b/tests/ambiguity_heuristic.rs
@@ -127,10 +127,18 @@ fn antecedent_carries_across_sentence_boundary() {
 }
 
 #[rstest]
-#[case("Mercury.", 3.0)]
-#[case("Mercury-based alloys", 3.0)]
-#[case("Discuss Python's syntax.", 3.0)]
-#[case("Amazon, Nile, and Jordan", 7.0)]
+#[case("Mercuries' orbit.", 3.0)]
+#[case("Jaguar-based drivetrains.", 3.0)]
+#[case("APPLE supply nodes.", 3.0)]
+#[case("Delta-compatible avionics; Orion-guided telescopes.", 5.0)]
+#[case("Saturn's rings with Nile delta flows.", 7.0)]
+#[case(
+    concat!(
+        "Amazon / Nile logistics; Jordan-Mercury shipments; ",
+        "Apple-Orion payloads; Delta's Jaguar Python Saturn kits.",
+    ),
+    21.0,
+)]
 fn detects_ambiguous_entities_via_regex(#[case] text: &str, #[case] expected: f32) {
     assert_ambiguity_score(
         text,

--- a/tests/ambiguity_heuristic.rs
+++ b/tests/ambiguity_heuristic.rs
@@ -17,7 +17,7 @@ const PRONOUN_SAMPLES: &[&str] = &[
     "Theirs", "it", "he", "she", "they", "this", "that", "him", "her", "them", "his", "its",
     "their", "theirs",
 ];
-const CANDIDATE_NAMES: &[&str] = &["Alice", "Berlin", "Mercury", "Orion", "Sirius"];
+const CANDIDATE_NAMES: &[&str] = &["Alice", "Berlin", "Helena", "Sirius", "Tariq"];
 const FUNCTION_WORD_SAMPLES: &[&str] = &[
     "However",
     "Therefore",
@@ -123,6 +123,19 @@ fn antecedent_carries_across_sentence_boundary() {
         "Alice fixed it. However, they approved.",
         3.0,
         "expected antecedent to suppress the bonus across the boundary",
+    );
+}
+
+#[rstest]
+#[case("Mercury.", 3.0)]
+#[case("Mercury-based alloys", 3.0)]
+#[case("Discuss Python's syntax.", 3.0)]
+#[case("Amazon, Nile, and Jordan", 7.0)]
+fn detects_ambiguous_entities_via_regex(#[case] text: &str, #[case] expected: f32) {
+    assert_ambiguity_score(
+        text,
+        expected,
+        "expected curated regex lexicon to mark ambiguous entities",
     );
 }
 

--- a/tests/features/heuristic_scoring/ambiguous.feature
+++ b/tests/features/heuristic_scoring/ambiguous.feature
@@ -9,6 +9,6 @@ Feature: Heuristic scoring - ambiguous phrasing
     And the scored total is 2.0
 
   Scenario: scoring curated ambiguous entity lexicon
-    When scoring "Mercury-based alloys or Amazon logistics?"
+    When scoring "Mercury-based alloys and Amazon logistics?"
     Then the scored complexity components are 0.0, 1.0, 5.0
     And the scored total is 6.0

--- a/tests/features/heuristic_scoring/ambiguous.feature
+++ b/tests/features/heuristic_scoring/ambiguous.feature
@@ -7,3 +7,8 @@ Feature: Heuristic scoring - ambiguous phrasing
     When scoring "A few cats chase a dog; what happens?"
     Then the scored complexity components are 0.0, 0.0, 2.0
     And the scored total is 2.0
+
+  Scenario: scoring curated ambiguous entity lexicon
+    When scoring "Mercury-based alloys or Amazon logistics?"
+    Then the scored complexity components are 0.0, 1.0, 5.0
+    And the scored total is 6.0

--- a/tests/score_bdd.rs
+++ b/tests/score_bdd.rs
@@ -175,6 +175,11 @@ fn score_ambiguous_question(test_context: TestContext) {
     let _ = test_context;
 }
 
+#[scenario(path = "tests/features/heuristic_scoring/ambiguous.feature", index = 1)]
+fn score_ambiguous_lexicon_variants(test_context: TestContext) {
+    let _ = test_context;
+}
+
 #[scenario(path = "tests/features/heuristic_scoring/empty_query.feature")]
 fn score_empty_query(test_context: TestContext) {
     let _ = test_context;

--- a/tests/score_bdd.rs
+++ b/tests/score_bdd.rs
@@ -178,8 +178,10 @@ fn score_ambiguous_question(test_context: TestContext) {
 #[scenario(path = "tests/features/heuristic_scoring/ambiguous.feature", index = 1)]
 fn score_ambiguous_lexicon_variants(test_context: TestContext) {
     let components = test_context.scored_ok();
-    assert_close(components.ambiguity(), 5.0);
+    assert_close(components.scope(), 0.0);
     assert_close(components.depth(), 1.0);
+    assert_close(components.ambiguity(), 5.0);
+    assert_close(components.total(), 6.0);
 }
 
 #[scenario(path = "tests/features/heuristic_scoring/empty_query.feature")]

--- a/tests/score_bdd.rs
+++ b/tests/score_bdd.rs
@@ -177,7 +177,9 @@ fn score_ambiguous_question(test_context: TestContext) {
 
 #[scenario(path = "tests/features/heuristic_scoring/ambiguous.feature", index = 1)]
 fn score_ambiguous_lexicon_variants(test_context: TestContext) {
-    let _ = test_context;
+    let components = test_context.scored_ok();
+    assert_close(components.ambiguity(), 5.0);
+    assert_close(components.depth(), 1.0);
 }
 
 #[scenario(path = "tests/features/heuristic_scoring/empty_query.feature")]


### PR DESCRIPTION
## Summary
- replace token equality matching with a regex-driven ambiguous entity pass and cache the curated lexicon
- drop the unused singularisation helpers and extend unit, integration, and BDD coverage for plurals, possessives, and punctuation
- document the new pre-pass, add the regression seed ledger, and mark the roadmap item complete

## Testing
- make fmt
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68dada8809dc8322bf701243a302f87c

## Summary by Sourcery

Implement a regex-driven pre-pass for ambiguous entity detection, replacing the previous token-level singularisation approach, and update related utilities, documentation, and tests accordingly.

New Features:
- Add regex-based pre-pass to detect ambiguous entities using a curated lexicon of case-insensitive word-boundary patterns

Enhancements:
- Replace token equality and singularisation matching with regex scoring and cache precompiled patterns
- Remove unused singularisation helper functions from text utilities

Documentation:
- Update the function design doc to reflect regex-based ambiguous entity matching
- Mark the new regex pre-pass as complete in the project roadmap

Tests:
- Extend unit, integration, and BDD tests to cover plurals, possessives, punctuation, and curated entity detection
- Add a proptest regression seed ledger for the ambiguity heuristic