### PR TITLE
Diversify ambiguous entity unit coverage

### DIFF
--- a/src/heuristics/ambiguity.rs
+++ b/src/heuristics/ambiguity.rs
@@ -148,9 +148,9 @@ mod tests {
     }
 
     #[rstest]
-    #[case("Mercury-class Apple launches.", 5.0)]
-    #[case("Jaguar versus Delta at Orion Station.", 7.0)]
-    #[case("Saturn pipelines for Amazon Nile freight.", 7.0)]
+    #[case("Mercury,Amazon,Nile routes pivot.", 7.0)]
+    #[case("Orion! Delta? Jaguar.", 7.0)]
+    #[case("Amazon; Nile: Mercury.", 7.0)]
     fn recognises_ambiguous_entities(#[case] query: &str, #[case] expected: f32) {
         let h = AmbiguityHeuristic;
         assert_eq!(h.process(query), Ok(expected));


### PR DESCRIPTION
## Summary
- replace ambiguous entity unit test cases with punctuation-heavy inputs to avoid duplicating integration coverage

## Testing
- make fmt
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68ddb56d25448322957515317aa9b365

## Summary by Sourcery

Tests:
- Replace ambiguous entity unit tests with punctuation-heavy query inputs to broaden coverage