### PR TITLE
Detail ONNX roadmap tasks

### DIFF
--- a/docs/documentation-style-guide.md
+++ b/docs/documentation-style-guide.md
@@ -7,16 +7,16 @@ these rules to keep the documentation clear and consistent for developers.
 
 - Use British English based on the
   [Oxford English Dictionary](https://public.oed.com/) (en-GB-oxendict):
-   - suffix -ize in words like _realize_ and _organization_ instead of
+  - suffix -ize in words like _realize_ and _organization_ instead of
      -ise endings,
-   - suffix ‑lyse in words not traced to the Greek ‑izo, ‑izein suffixes,
+  - suffix ‑lyse in words not traced to the Greek ‑izo, ‑izein suffixes,
      such as _analyse_, _paralyse_ and _catalyse_,
-   - suffix -our in words such as _colour_, _behaviour_ and _neighbour_,
-   - suffix -re in words such as _calibre_, _centre_ and fibre,
-   - double "l" in words such as _cancelled_, _counsellor_ and _cruellest_,
-   - maintain the "e" in words such as _likeable_, _liveable_ and _rateable_,
-   - suffix -ogue in words such as _analogue_ and _catalogue_,
-   - and so forth.
+  - suffix -our in words such as _colour_, _behaviour_ and _neighbour_,
+  - suffix -re in words such as _calibre_, _centre_ and fibre,
+  - double "l" in words such as _cancelled_, _counsellor_ and _cruellest_,
+  - maintain the "e" in words such as _likeable_, _liveable_ and _rateable_,
+  - suffix -ogue in words such as _analogue_ and _catalogue_,
+  - and so forth.
 - The word **"outwith"** is acceptable.
 - Keep US spelling when used in an API, for example `color`.
 - The project licence file is spelled `LICENSE` for community consistency.
@@ -122,31 +122,31 @@ flowchart TD
 ## Roadmap Task Writing Guidelines
 
 When documenting development roadmap items, write them so that they are
-achievable, measurable, and structured. This ensures the roadmap functions as
-a practical planning tool rather than a vague wishlist. Do not commit to
-timeframes in the roadmap. Development effort should be roughly consistent
-from task to task.
+achievable, measurable, and structured. This ensures the roadmap functions as a
+practical planning tool rather than a vague wishlist. Do not commit to
+timeframes in the roadmap. Development effort should be roughly consistent from
+task to task.
 
 ### Principles for Roadmap Tasks
 
 - Define outcomes, not intentions: Phrase tasks in terms of the capability
-  delivered (e.g. “Implement role-based access control for API endpoints”),
-  not aspirations like “Improve security”.
+  delivered (e.g. “Implement role-based access control for API endpoints”), not
+  aspirations like “Improve security”.
 - Quantify completion criteria: Attach measurable finish lines (e.g. “90%
   test coverage for new modules”, “response times under 200ms”, “all endpoints
   migrated”).
 - Break into atomic increments: Ensure tasks can be completed in weeks, not
   quarters. Large goals should be decomposed into clear, deliverable units.
 - Tie to dependencies and sequencing: Document prerequisites so tasks can be
-  scheduled realistically (e.g. “Introduce central logging service” before
-  “Add error dashboards”).
+  scheduled realistically (e.g. “Introduce central logging service” before “Add
+  error dashboards”).
 - Bound scope explicitly: Note both in-scope and out-of-scope elements (e.g.
   “Build analytics dashboard (excluding churn prediction)”).
 
 ### Hierarchy of Scope
 
-Roadmaps should be expressed in three layers of scope to maintain clarity
-and navigability:
+Roadmaps should be expressed in three layers of scope to maintain clarity and
+navigability:
 
 - Phases (strategic milestones) – Broad outcome-driven stages that represent
   significant capability shifts. Why the work matters.
@@ -155,6 +155,6 @@ and navigability:
 - Tasks (execution units) – Small, measurable pieces of work with clear
   acceptance criteria. How it gets done.
 
----
+______________________________________________________________________
 
 [^markdownlint]: A linter that enforces consistent Markdown formatting.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -46,10 +46,46 @@ relying on fast, lightweight heuristics.
 This phase focuses on enhancing accuracy with model-based providers and
 optimizing for performance.
 
-- [ ] Train or adapt and export the initial ONNX models for depth and ambiguity
-  classification.
-- [ ] Implement the `DepthClassifierOnnx` and `AmbiguityClassifierOnnx`
-  providers, gated by the `onnx` feature flag.
+- [ ] Deliver the depth classifier ONNX artefact as specified in the accepted
+  ADR:
+  - [ ] Fine-tune the DistilBERT ordinal model on ordered depth bins, confirm
+    the expected-value projection matches the Sigma calibration interface, and
+    export the opset 17 graph with pinned tokenizer assets.
+  - [ ] Apply post-training static INT8 quantisation, benchmark CPU latency to
+    p95 ≤ 10 ms, and record calibration coefficients for the provider
+    configuration.
+  - [ ] Publish the model package with checksum manifest, versioned artefact
+    paths, and documentation of fallback MLP expectations.
+- [ ] Produce the ambiguity classifier ONNX artefact aligned with the design
+  document:
+  - [ ] Curate and label the ambiguity dataset (AmbigQA plus curated edge
+    cases) into the Clear / Possibly Ambiguous / Highly Ambiguous classes
+    defined in the design.
+  - [ ] Fine-tune the lightweight transformer, export the ONNX graph with the
+    categorical-to-numeric mapping required by Sigma, and pin the tokenizer
+    vocabulary.
+  - [ ] Quantise and benchmark the graph to meet latency and footprint targets,
+    then publish artefacts and checksum metadata alongside calibration notes.
+- [ ] Implement the `DepthClassifierOnnx` provider behind the `onnx` feature
+  flag:
+  - [ ] Load the opset 17 session through `ort`, enforce checksum validation,
+    and wire the expected-value scalar projection into
+    `TextProcessor<Output = f32>` per the ADR.
+  - [ ] Integrate tracing, metrics, and configuration plumbing (model paths,
+    quantisation variant selection, calibration coefficients) consistent with
+    the Complexity pipeline.
+  - [ ] Extend golden traces and unit tests to cover inference happy paths,
+    error mapping, and deterministic outputs across feature combinations.
+- [ ] Implement the `AmbiguityClassifierOnnx` provider behind the `onnx`
+  feature flag:
+  - [ ] Mirror the runtime scaffolding (session loading, checksum enforcement,
+    feature gating) used by the depth provider while mapping class logits to
+    the numeric ambiguity score expected by Sigma.
+  - [ ] Expose configuration toggles for model variants and calibration, add
+    tracing and metrics instrumentation, and ensure integration with
+    `DefaultComplexity`.
+  - [ ] Expand regression tests and golden traces to validate deterministic
+    scoring and parity with the documented ambiguity thresholds.
 - [ ] Implement the `score_batch` method and integrate `rayon` for parallel
   execution.
 - [ ] Set up the `criterion` benchmarking suite and implement the initial set


### PR DESCRIPTION
## Summary
- decompose the Phase 2 roadmap into granular ONNX model and provider tasks aligned with the ADR and design guidance
- normalise the documentation style guide formatting to comply with the formatting toolchain

## Testing
- make fmt
- make markdownlint

------
https://chatgpt.com/codex/tasks/task_e_68def05b8bf483228c201a336c0b0930