### PR TITLE
Add scheduled mutation testing via the shared workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,13 @@ jobs:
         run: make check-fmt
       - name: Lint
         run: make lint
+      - name: Setup uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+        with:
+          python-version: '3.13'
+          enable-cache: true
+      - name: Workflow contract tests
+        run: make test-workflow-contracts
       - name: Test
         run: make test
       - name: Run coverage

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -1,0 +1,24 @@
+name: Mutation testing
+
+# Thin caller of the shared mutation-testing reusable workflow; caller
+# guide: leynos/shared-actions docs/mutation-cargo-workflow.md.
+on:
+  schedule:
+    - cron: "20 9 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: mutation-testing-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  mutation:
+    permissions:
+      contents: read
+      id-token: write # OIDC workflow-source resolution
+    uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@859416a90eb3987b46a57682c5d6b8964ad3f0a6
+    with:
+      extra-args: "--all-features"
+      exclude-globs: "src/tests/**,tests/support/**,src/bin/bless_traces.rs"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target/
 **/*.rs.bk
 .memdb/
+__pycache__/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help all clean test build release lint typecheck fmt check-fmt markdownlint nixie bless
+.PHONY: help all clean test test-workflow-contracts build release lint typecheck fmt check-fmt markdownlint nixie bless
 
 APP ?= lag-complexity
 CARGO ?= cargo
@@ -17,6 +17,9 @@ clean: ## Remove build artifacts
 
 test: ## Run tests with warnings treated as errors
 	RUSTFLAGS="-D warnings" $(CARGO) test --all-targets --all-features $(BUILD_JOBS)
+
+test-workflow-contracts: ## Validate the mutation-testing caller contract
+	uv run --with 'pytest>=8' --with 'pyyaml>=6' pytest tests/workflow_contracts -q
 
 target/%/$(APP): ## Build binary in debug or release mode
 	$(CARGO) build $(BUILD_JOBS) $(if $(findstring release,$(@)),--release) --bin $(APP)

--- a/tests/workflow_contracts/mutation_testing_test.py
+++ b/tests/workflow_contracts/mutation_testing_test.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 import yaml
 
 WORKFLOW_PATH = (
@@ -39,8 +40,9 @@ EXPECTED_WITH = {
 }
 
 
-def _load() -> dict[str, object]:
-    """Parse the workflow file."""
+@pytest.fixture(scope="module")
+def workflow() -> dict[str, object]:
+    """Parse the workflow file once per module."""
     return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
 
 
@@ -62,9 +64,9 @@ def _mutation_job(workflow: dict[str, object]) -> dict[str, object]:
     return jobs["mutation"]
 
 
-def test_uses_reference_is_pinned_to_the_documented_sha() -> None:
+def test_uses_reference_is_pinned_to_the_documented_sha(workflow: dict[str, object]) -> None:
     """The job must call the shared workflow at the exact documented SHA."""
-    uses = _mutation_job(_load()).get("uses")
+    uses = _mutation_job(workflow).get("uses")
     assert uses is not None, "jobs.mutation.uses is missing"
     path, _, ref = uses.partition("@")
     assert path == "leynos/shared-actions/.github/workflows/mutation-cargo.yml", (
@@ -84,27 +86,26 @@ def test_uses_reference_is_pinned_to_the_documented_sha() -> None:
     )
 
 
-def test_job_permissions_are_exactly_least_privilege() -> None:
+def test_job_permissions_are_exactly_least_privilege(workflow: dict[str, object]) -> None:
     """The job grants contents: read and id-token: write, nothing broader."""
-    permissions = _mutation_job(_load()).get("permissions")
+    permissions = _mutation_job(workflow).get("permissions")
     assert permissions == {"contents": "read", "id-token": "write"}, (
         "jobs.mutation.permissions must be exactly "
         f"{{'contents': 'read', 'id-token': 'write'}}, got {permissions!r}"
     )
 
 
-def test_workflow_default_permissions_are_empty() -> None:
+def test_workflow_default_permissions_are_empty(workflow: dict[str, object]) -> None:
     """The workflow-level default token scope is empty."""
-    workflow = _load()
     assert workflow.get("permissions") == {}, (
         f"top-level permissions must be an empty mapping, got "
         f"{workflow.get('permissions')!r}"
     )
 
 
-def test_concurrency_serializes_per_ref_without_cancelling() -> None:
+def test_concurrency_serializes_per_ref_without_cancelling(workflow: dict[str, object]) -> None:
     """Runs queue per ref instead of cancelling one another."""
-    concurrency = _load().get("concurrency")
+    concurrency = workflow.get("concurrency")
     assert isinstance(concurrency, dict), "the workflow must declare concurrency"
     assert concurrency.get("group") == "mutation-testing-${{ github.ref }}", (
         f"concurrency.group must key on the triggering ref, got "
@@ -116,9 +117,9 @@ def test_concurrency_serializes_per_ref_without_cancelling() -> None:
     )
 
 
-def test_triggers_keep_schedule_and_plain_dispatch() -> None:
+def test_triggers_keep_schedule_and_plain_dispatch(workflow: dict[str, object]) -> None:
     """The daily schedule stays; dispatch has no legacy branch input."""
-    triggers = _triggers(_load())
+    triggers = _triggers(workflow)
     schedule = triggers.get("schedule")
     assert schedule == [{"cron": "20 9 * * *"}], (
         f"on.schedule must be the daily 09:20 UTC cron, got {schedule!r}"
@@ -132,9 +133,9 @@ def test_triggers_keep_schedule_and_plain_dispatch() -> None:
     )
 
 
-def test_with_block_carries_the_caller_configuration() -> None:
+def test_with_block_carries_the_caller_configuration(workflow: dict[str, object]) -> None:
     """The caller passes exactly the feature args and scaffolding excludes."""
-    with_block = _mutation_job(_load()).get("with")
+    with_block = _mutation_job(workflow).get("with")
     assert isinstance(with_block, dict), "jobs.mutation.with is missing"
     assert with_block == EXPECTED_WITH, (
         f"jobs.mutation.with must be exactly {EXPECTED_WITH!r} (mirror the CI "

--- a/tests/workflow_contracts/mutation_testing_test.py
+++ b/tests/workflow_contracts/mutation_testing_test.py
@@ -1,0 +1,143 @@
+"""Contract tests for the mutation-testing caller workflow.
+
+The executable logic lives in the ``leynos/shared-actions`` reusable
+workflow, which carries its own unit and integration tests;
+lag-complexity's caller is declarative configuration. These tests parse
+the caller with PyYAML and pin the contract it must uphold, so drift
+(repointing the pin at a branch, widening permissions, or losing the
+feature and scaffolding configuration) fails CI on the pull request
+rather than surfacing in a scheduled or manual run.
+
+Run via ``make test-workflow-contracts``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+WORKFLOW_PATH = (
+    Path(__file__).resolve().parents[2] / ".github" / "workflows" / "mutation-testing.yml"
+)
+
+#: The leynos/shared-actions commit the caller pins. Bump the workflow
+#: and this constant together.
+PINNED_SHA = "859416a90eb3987b46a57682c5d6b8964ad3f0a6"
+
+EXPECTED_USES = (
+    "leynos/shared-actions/.github/workflows/mutation-cargo.yml@" + PINNED_SHA
+)
+
+#: The exact caller configuration: mirror the CI baseline's
+#: --all-features, and exclude test scaffolding (the re-exported
+#: src/tests module and tests/support helpers) plus the manually run
+#: golden-snapshot regenerator, none of which the test suite guards.
+EXPECTED_WITH = {
+    "extra-args": "--all-features",
+    "exclude-globs": "src/tests/**,tests/support/**,src/bin/bless_traces.rs",
+}
+
+
+def _load() -> dict[str, object]:
+    """Parse the workflow file."""
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+def _triggers(workflow: dict[str, object]) -> dict[str, object]:
+    """Return the ``on:`` mapping (PyYAML parses the bare key as True)."""
+    triggers = workflow.get("on", workflow.get(True))
+    assert isinstance(triggers, dict), "the workflow must declare an on: mapping"
+    return triggers
+
+
+def _mutation_job(workflow: dict[str, object]) -> dict[str, object]:
+    """Return the single calling job."""
+    jobs = workflow.get("jobs")
+    assert isinstance(jobs, dict), "the workflow must declare a jobs mapping"
+    assert jobs, "the workflow must declare at least one job"
+    assert list(jobs) == ["mutation"], (
+        f"expected a single job named 'mutation', found {sorted(jobs)}"
+    )
+    return jobs["mutation"]
+
+
+def test_uses_reference_is_pinned_to_the_documented_sha() -> None:
+    """The job must call the shared workflow at the exact documented SHA."""
+    uses = _mutation_job(_load()).get("uses")
+    assert uses is not None, "jobs.mutation.uses is missing"
+    path, _, ref = uses.partition("@")
+    assert path == "leynos/shared-actions/.github/workflows/mutation-cargo.yml", (
+        f"jobs.mutation.uses must reference mutation-cargo.yml, got {path!r}"
+    )
+    assert len(ref) == 40, (
+        f"jobs.mutation.uses must pin a full 40-character commit SHA, "
+        f"not a branch or tag: {ref!r}"
+    )
+    assert all(c in "0123456789abcdef" for c in ref), (
+        f"jobs.mutation.uses must pin a lowercase hex commit SHA, "
+        f"not a branch or tag: {ref!r}"
+    )
+    assert uses == EXPECTED_USES, (
+        f"jobs.mutation.uses pins {ref!r}; this test documents {PINNED_SHA!r} — "
+        "bump this test together with the workflow"
+    )
+
+
+def test_job_permissions_are_exactly_least_privilege() -> None:
+    """The job grants contents: read and id-token: write, nothing broader."""
+    permissions = _mutation_job(_load()).get("permissions")
+    assert permissions == {"contents": "read", "id-token": "write"}, (
+        "jobs.mutation.permissions must be exactly "
+        f"{{'contents': 'read', 'id-token': 'write'}}, got {permissions!r}"
+    )
+
+
+def test_workflow_default_permissions_are_empty() -> None:
+    """The workflow-level default token scope is empty."""
+    workflow = _load()
+    assert workflow.get("permissions") == {}, (
+        f"top-level permissions must be an empty mapping, got "
+        f"{workflow.get('permissions')!r}"
+    )
+
+
+def test_concurrency_serializes_per_ref_without_cancelling() -> None:
+    """Runs queue per ref instead of cancelling one another."""
+    concurrency = _load().get("concurrency")
+    assert isinstance(concurrency, dict), "the workflow must declare concurrency"
+    assert concurrency.get("group") == "mutation-testing-${{ github.ref }}", (
+        f"concurrency.group must key on the triggering ref, got "
+        f"{concurrency.get('group')!r}"
+    )
+    assert concurrency.get("cancel-in-progress") is False, (
+        f"concurrency.cancel-in-progress must be false, got "
+        f"{concurrency.get('cancel-in-progress')!r}"
+    )
+
+
+def test_triggers_keep_schedule_and_plain_dispatch() -> None:
+    """The daily schedule stays; dispatch has no legacy branch input."""
+    triggers = _triggers(_load())
+    schedule = triggers.get("schedule")
+    assert schedule == [{"cron": "20 9 * * *"}], (
+        f"on.schedule must be the daily 09:20 UTC cron, got {schedule!r}"
+    )
+    assert "workflow_dispatch" in triggers, "on.workflow_dispatch is missing"
+    dispatch = triggers.get("workflow_dispatch") or {}
+    inputs = dispatch.get("inputs") or {}
+    assert "branch" not in inputs, (
+        "on.workflow_dispatch must not declare a branch input; the Actions "
+        "run-workflow control selects the ref"
+    )
+
+
+def test_with_block_carries_the_caller_configuration() -> None:
+    """The caller passes exactly the feature args and scaffolding excludes."""
+    with_block = _mutation_job(_load()).get("with")
+    assert isinstance(with_block, dict), "jobs.mutation.with is missing"
+    assert with_block == EXPECTED_WITH, (
+        f"jobs.mutation.with must be exactly {EXPECTED_WITH!r} (mirror the CI "
+        f"--all-features baseline and exclude test scaffolding), got "
+        f"{with_block!r}"
+    )


### PR DESCRIPTION
## Summary

Enrols lag-complexity in the estate-wide scheduled mutation testing rollout. This pull request adds a thin caller of the [leynos/shared-actions mutation-cargo reusable workflow](https://github.com/leynos/shared-actions/blob/main/docs/mutation-cargo-workflow.md), pinned to commit `859416a90eb3987b46a57682c5d6b8964ad3f0a6`, following the estate template established in [leynos/wireframe#572](https://github.com/leynos/wireframe/pull/572). The run is informational only — a daily scoped guard at 09:20 UTC plus sharded full runs on manual dispatch — and never gates merges.

## Configuration for this repository

- [`.github/workflows/mutation-testing.yml`](https://github.com/leynos/lag-complexity/blob/add-mutation-testing/.github/workflows/mutation-testing.yml) — the caller. It sets only what this repository needs:
  - `extra-args: "--all-features"` mirrors the CI test baseline (`make test` runs `cargo test --all-targets --all-features`), so feature-gated code (`cli`, `json5`, `yaml`, `toml`, `provider-api`) is built and tested against mutants.
  - `exclude-globs: "src/tests/**,tests/support/**,src/bin/bless_traces.rs"` excludes test scaffolding — `src/tests` re-exports `tests/support` into the library (via `#[path]`), so both would otherwise be mutation targets — and the golden-snapshot regenerator `bless_traces`, which is invoked manually (`make bless`) and not guarded by the test suite. Mutants there would only be noise survivors.
  - The `paths` input is omitted: the default (`src/,examples/,benches/`) already covers this single-crate layout. `--test-workspace` is omitted because the repository is not a cargo workspace, and no `setup-commands` are needed (no custom linker).
- [`tests/workflow_contracts/mutation_testing_test.py`](https://github.com/leynos/lag-complexity/blob/add-mutation-testing/tests/workflow_contracts/mutation_testing_test.py) — contract tests that parse the caller with PyYAML and pin the SHA, least-privilege permissions, per-ref non-cancelling concurrency, the 09:20 UTC cron slot, and the exact `with:` block, so drift fails CI on the pull request rather than surfacing in a scheduled run.
- [`Makefile`](https://github.com/leynos/lag-complexity/blob/add-mutation-testing/Makefile) — a `test-workflow-contracts` target running the suite via `uv run` with pytest and PyYAML.
- [`.github/workflows/ci.yml`](https://github.com/leynos/lag-complexity/blob/add-mutation-testing/.github/workflows/ci.yml) — a pinned `astral-sh/setup-uv` step and the contract-test step after Lint in the `build-test` job.
- [`.gitignore`](https://github.com/leynos/lag-complexity/blob/add-mutation-testing/.gitignore) — now covers `__pycache__/`.

## Known limitation: baseline currently blocked (#66)

Baseline verification found that plain `cargo test --all-features` — what cargo-mutants runs to validate the unmutated tree — fails on three doctests in `src/heuristics/text.rs`, which import the `pub(crate)` module `heuristics::text` from outside the crate. CI stays green because `--all-targets` skips doctests. Until [#66](https://github.com/leynos/lag-complexity/issues/66) is resolved, the scheduled run will report a failed baseline rather than mutation results. The workflow is informational, so enrolment proceeds regardless.

## Validation

- `python3 -c "import yaml; …"` — both workflow files parse.
- `actionlint` — clean on `mutation-testing.yml` and `ci.yml`.
- `make test-workflow-contracts` — 6 passed.
- Negative pin test: repointing the `uses:` ref to `@v1` fails `test_uses_reference_is_pinned_to_the_documented_sha`; restoring the SHA returns the suite to green.
