### PR TITLE
Wire CodeScene coverage upload on main and prepare the PR gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,14 @@ jobs:
       CARGO_TERM_COLOR: always
       BUILD_PROFILE: debug
       WHITAKER_INSTALLER_VERSION: '0.2.5'
+      CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN || '' }}
+      CODESCENE_CLI_SHA256: ${{ vars.CODESCENE_CLI_SHA256 || '' }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@v1.1.0
+        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
       - name: Format
         run: make check-fmt
       - name: Cache whitaker installer
@@ -50,18 +54,20 @@ jobs:
         run: make test-workflow-contracts
       - name: Test
         run: make test
-      - name: Run coverage
-        uses: leynos/shared-actions/.github/actions/generate-coverage@f9f1c863c8a5bef64aa6779caa746e1a4a6c1ad4
+      - name: Generate coverage
+        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
           output-path: lcov.info
           format: lcov
-      - name: Upload coverage data to CodeScene
-        env:
-          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
-        if: ${{ env.CS_ACCESS_TOKEN }}
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@1213d7874aa42ff034587d9385f35178d51e1f65
-        with:
-          format: lcov
-          access-token: ${{ env.CS_ACCESS_TOKEN }}
-          installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}
-
+          use-cargo-nextest: 'false'
+          with-ratchet: 'true'
+      # The `mode: check` step is deliberately not wired in yet: CodeScene
+      # project 70676 has no coverage-gates configuration, so
+      # `cs-coverage check` fails every run with "HTTP call succeeded,
+      # but the received project-config isn't valid. Lacks the gates
+      # configuration." — a CodeScene-side per-project setting, not a CI
+      # defect (ddlint and chutoro projects hit the byte-identical error;
+      # see ddlint#287). Add the check step in a fast-follow PR once
+      # coverage-main.yml has uploaded to main at least once and the gate
+      # is confirmed to resolve, or once CodeScene confirms the project's
+      # coverage gate is enabled.

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -1,0 +1,43 @@
+name: Coverage (main)
+
+# CodeScene accepts `cs-coverage upload` only for analysed branches, so
+# main-branch coverage is uploaded here on push; pull requests run the
+# changed-line gate (`cs-coverage check`) in ci.yml instead — once the
+# CodeScene project's coverage gate is enabled (see the deferred-gate
+# note in ci.yml). This workflow also advances the coverage ratchet
+# baseline: caches saved on main are readable by every pull-request run,
+# so the baseline written here is the one PR ratchet checks compare
+# against.
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  coverage-upload:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      CARGO_TERM_COLOR: always
+      BUILD_PROFILE: debug
+      CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN || '' }}
+      CODESCENE_CLI_SHA256: ${{ vars.CODESCENE_CLI_SHA256 || '' }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Rust
+        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+      - name: Generate coverage
+        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          output-path: lcov.info
+          format: lcov
+          use-cargo-nextest: 'false'
+          with-ratchet: 'true'
+      - name: Upload coverage data to CodeScene
+        if: env.CS_ACCESS_TOKEN
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          format: lcov
+          access-token: ${{ env.CS_ACCESS_TOKEN }}
+          installer-checksum: ${{ env.CODESCENE_CLI_SHA256 }}

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -25,6 +25,6 @@ jobs:
       statuses: read # Inspects legacy required status contexts before auto-merge.
       id-token: write # Reads reusable workflow OIDC metadata; no external cloud auth.
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.user.login == 'dependabot[bot]' }}
-    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@1213d7874aa42ff034587d9385f35178d51e1f65
+    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
     with:
       pull-request-number: ${{ inputs.pull-request-number || github.event.pull_request.number }}

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       contents: read
       id-token: write # OIDC workflow-source resolution
-    uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@859416a90eb3987b46a57682c5d6b8964ad3f0a6
+    uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
     with:
       extra-args: "--all-features"
       exclude-globs: "src/tests/**,tests/support/**,src/bin/bless_traces.rs"

--- a/tests/workflow_contracts/mutation_testing_test.py
+++ b/tests/workflow_contracts/mutation_testing_test.py
@@ -24,7 +24,7 @@ WORKFLOW_PATH = (
 
 #: The leynos/shared-actions commit the caller pins. Bump the workflow
 #: and this constant together.
-PINNED_SHA = "859416a90eb3987b46a57682c5d6b8964ad3f0a6"
+PINNED_SHA = "927edd45ae77be4251a8a18ca9eb5613a2e32cbd"
 
 EXPECTED_USES = (
     "leynos/shared-actions/.github/workflows/mutation-cargo.yml@" + PINNED_SHA

--- a/tests/workflows.rs
+++ b/tests/workflows.rs
@@ -7,14 +7,14 @@ use serde_yaml::Value;
 
 #[derive(Clone, Copy)]
 enum WorkflowFile {
-    Ci,
+    CoverageMain,
     DependabotAutomerge,
 }
 
 impl WorkflowFile {
     const fn path(self) -> &'static str {
         match self {
-            Self::Ci => ".github/workflows/ci.yml",
+            Self::CoverageMain => ".github/workflows/coverage-main.yml",
             Self::DependabotAutomerge => ".github/workflows/dependabot-automerge.yml",
         }
     }
@@ -33,23 +33,24 @@ struct Workflow {
 }
 
 #[test]
-fn ci_codescene_upload_gates_on_env_secret() -> Result<(), Box<dyn Error>> {
-    let workflow = read_workflow(WorkflowFile::Ci)?;
-    let steps = sequence_value(mapping_value_path(
-        &workflow.jobs,
-        &["build-test", "steps"],
-    )?)?;
-    let upload_step = named_step(steps, StepName("Upload coverage data to CodeScene"))?;
+fn coverage_main_upload_gates_on_env_secret() -> Result<(), Box<dyn Error>> {
+    // The CodeScene upload lives in coverage-main.yml (push to main), not
+    // the pull-request CI job: `cs-coverage upload` is accepted only for
+    // analysed branches. The job-level env supplies the token (empty when
+    // the secret is unset — e.g. forks), and the step guards on it so a
+    // token-less run skips the upload rather than failing.
+    let workflow = read_workflow(WorkflowFile::CoverageMain)?;
+    let job = mapping_value_path(&workflow.jobs, &["coverage-upload"])?;
 
-    let env = mapping_value(upload_step, "env")?;
+    let env = mapping_value(job, "env")?;
     assert_scalar_eq(
         mapping_value(env, "CS_ACCESS_TOKEN")?,
-        "${{ secrets.CS_ACCESS_TOKEN }}",
+        "${{ secrets.CS_ACCESS_TOKEN || '' }}",
     );
-    assert_scalar_eq(
-        mapping_value(upload_step, "if")?,
-        "${{ env.CS_ACCESS_TOKEN }}",
-    );
+
+    let steps = sequence_value(mapping_value(job, "steps")?)?;
+    let upload_step = named_step(steps, StepName("Upload coverage data to CodeScene"))?;
+    assert_scalar_eq(mapping_value(upload_step, "if")?, "env.CS_ACCESS_TOKEN");
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Onboards this repository to the CodeScene coverage pipeline, following the
estate rollout recipe (proven on [mxd#362](https://github.com/leynos/mxd/pull/362)
and modelled on [ddlint#287](https://github.com/leynos/ddlint/pull/287)).

The CodeScene GitHub App posts a `CodeScene Code Coverage` check on every
pull-request head and waits for coverage to be uploaded for that commit;
repositories that never upload leave the check waiting until it times out, and
a timed-out check poisons the whole status rollup — which the shared Dependabot
automerge gate reads in full, so automerge stalls even when every required
check is green. This wiring feeds CodeScene the coverage it expects.

`cs-coverage upload` is accepted only for branches CodeScene analyses (`main`),
so the upload lives in a dedicated push-to-main workflow. The pull-request job
generates line-level LCOV coverage and advances the ratchet baseline.

The changed-line PR gate (`mode: check`) is **deliberately deferred**: CodeScene
project 70676 has no coverage-gates configuration yet, so `cs-coverage check`
fails every run with "the received project-config isn't valid. Lacks the gates
configuration." — a CodeScene-side per-project setting, not a CI defect. A
comment in `ci.yml` records this; the step lands in a fast-follow once the gate
is enabled. Note the CodeScene coverage check is **not** a repository-required
check — it blocks only through the status rollup, so reviewers will not find it
in the branch ruleset.

## Review walkthrough

- [`.github/workflows/ci.yml`](https://github.com/leynos/lag-complexity/blob/codescene-coverage-gate/.github/workflows/ci.yml)
  — bumps the shared-actions pins to `927edd4`, checks out with
  `fetch-depth: 0` (so a later changed-line gate can reach the merge base),
  runs `generate-coverage` with `format: lcov`, `use-cargo-nextest: 'false'`
  (preserves the existing plain `cargo llvm-cov` behaviour) and
  `with-ratchet: 'true'`, and carries the deferred-gate comment in place of the
  removed upload step.
- [`.github/workflows/coverage-main.yml`](https://github.com/leynos/lag-complexity/blob/codescene-coverage-gate/.github/workflows/coverage-main.yml)
  — new; on push to `main`, regenerates coverage (ratchet on, writing the
  authoritative baseline every PR compares against) and uploads it to CodeScene
  under the empty-token guard.
- [`.github/workflows/mutation-testing.yml`](https://github.com/leynos/lag-complexity/blob/codescene-coverage-gate/.github/workflows/mutation-testing.yml)
  and [`dependabot-automerge.yml`](https://github.com/leynos/lag-complexity/blob/codescene-coverage-gate/.github/workflows/dependabot-automerge.yml)
  — pins bumped to the single repo-wide `927edd4` SHA.
- [`tests/workflows.rs`](https://github.com/leynos/lag-complexity/blob/codescene-coverage-gate/tests/workflows.rs)
  — relocates the guarded-upload contract from `ci.yml` to `coverage-main.yml`,
  where the upload step now lives (job-level token, step-level `if` guard).
- [`tests/workflow_contracts/mutation_testing_test.py`](https://github.com/leynos/lag-complexity/blob/codescene-coverage-gate/tests/workflow_contracts/mutation_testing_test.py)
  — bumps the pinned-SHA contract to match the workflow.

## Validation

- `python3 -c "import yaml; ..."` parses all four workflow files.
- `make test-workflow-contracts` (pytest) passes: 6 passed.
- The relocated Rust workflow contract runs under `make test` in the
  `build-test` job.
- `CS_ACCESS_TOKEN` set in both the Actions and Dependabot secret stores; a
  read-only probe of `GET /v2/projects/70676` returns 200 with the estate PAT.

The ratchet baseline is written by the first `coverage-main.yml` run on `main`
after merge; the ratchet may report no stored baseline on this PR until then.
