### PR TITLE
Let Dependabot own the mutation-testing caller's pinned SHA

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -58,3 +58,38 @@ For `pull_request_target` events, the workflow gate must check
 `pull_request_target` workflow for a Dependabot-authored pull request, and the
 actor then differs from the pull request author. `workflow_dispatch` remains
 allowed for manual operation.
+
+## Workflow pins and Dependabot
+
+Dependabot owns the upgrade of GitHub Actions and reusable workflows,
+including calls into `leynos/shared-actions`. Contract tests that assert a
+caller's exact commit SHA create a lockstep dependency: every time Dependabot
+opens a bump PR, the test fails until a human edits the pinned constant to
+match. That defeats the purpose of automated dependency updates and turns a
+routine bump into a manual chore.
+
+Contract tests may still verify the *shape* of a reusable-workflow caller.
+They must not verify the specific SHA value.
+
+- Do assert the workflow references the correct reusable workflow path.
+- Do assert the ref is pinned to a full 40-character commit SHA, not a
+  mutable branch such as `main` or `rolling`.
+- Do assert the expected `on:` triggers, least-privilege `permissions:`, and
+  the inputs the caller relies on.
+- Do not hard-code the current SHA value as an expected string. Match it with
+  a pattern instead.
+- Do not fail a test purely because Dependabot bumped the pinned SHA.
+
+```python
+import re
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+def test_uses_pinned_full_sha(caller_step):
+    ref = caller_step["uses"].split("@")[-1]
+    assert SHA_RE.match(ref), f"expected a 40-hex commit SHA, got {ref!r}"
+```
+
+If a workflow's behaviour genuinely depends on a feature only present from a
+particular commit onwards, express that as a comment or a changelog note, not
+as a test assertion on the SHA string.

--- a/tests/workflow_contracts/mutation_testing_test.py
+++ b/tests/workflow_contracts/mutation_testing_test.py
@@ -3,16 +3,18 @@
 The executable logic lives in the ``leynos/shared-actions`` reusable
 workflow, which carries its own unit and integration tests;
 lag-complexity's caller is declarative configuration. These tests parse
-the caller with PyYAML and pin the contract it must uphold, so drift
-(repointing the pin at a branch, widening permissions, or losing the
-feature and scaffolding configuration) fails CI on the pull request
-rather than surfacing in a scheduled or manual run.
+the caller with PyYAML and pin the shape of the contract it must uphold:
+that it calls the correct reusable workflow at a commit SHA (not a branch
+or tag), and that permissions, triggers, and inputs match. Dependabot owns
+the pinned SHA value; these tests do not assert which SHA is pinned, so a
+routine Dependabot bump does not fail CI on the pull request.
 
 Run via ``make test-workflow-contracts``.
 """
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -22,12 +24,10 @@ WORKFLOW_PATH = (
     Path(__file__).resolve().parents[2] / ".github" / "workflows" / "mutation-testing.yml"
 )
 
-#: The leynos/shared-actions commit the caller pins. Bump the workflow
-#: and this constant together.
-PINNED_SHA = "927edd45ae77be4251a8a18ca9eb5613a2e32cbd"
-
-EXPECTED_USES = (
-    "leynos/shared-actions/.github/workflows/mutation-cargo.yml@" + PINNED_SHA
+#: The reusable workflow path the caller must reference, pinned to a full
+#: 40-hex commit SHA. Dependabot owns the SHA value; do not hard-code it.
+USES_RE = re.compile(
+    r"^leynos/shared-actions/\.github/workflows/mutation-cargo\.yml@[0-9a-f]{40}$"
 )
 
 #: The exact caller configuration: mirror the CI baseline's
@@ -64,25 +64,19 @@ def _mutation_job(workflow: dict[str, object]) -> dict[str, object]:
     return jobs["mutation"]
 
 
-def test_uses_reference_is_pinned_to_the_documented_sha(workflow: dict[str, object]) -> None:
-    """The job must call the shared workflow at the exact documented SHA."""
+def test_uses_reference_is_pinned_to_a_commit_sha(workflow: dict[str, object]) -> None:
+    """The job must call mutation-cargo.yml pinned to a commit SHA.
+
+    Dependabot owns the SHA value, so this asserts the shape of the pin
+    (correct reusable workflow path, full 40-hex commit SHA, not a branch
+    or tag) rather than a specific SHA.
+    """
     uses = _mutation_job(workflow).get("uses")
     assert uses is not None, "jobs.mutation.uses is missing"
-    path, _, ref = uses.partition("@")
-    assert path == "leynos/shared-actions/.github/workflows/mutation-cargo.yml", (
-        f"jobs.mutation.uses must reference mutation-cargo.yml, got {path!r}"
-    )
-    assert len(ref) == 40, (
-        f"jobs.mutation.uses must pin a full 40-character commit SHA, "
-        f"not a branch or tag: {ref!r}"
-    )
-    assert all(c in "0123456789abcdef" for c in ref), (
-        f"jobs.mutation.uses must pin a lowercase hex commit SHA, "
-        f"not a branch or tag: {ref!r}"
-    )
-    assert uses == EXPECTED_USES, (
-        f"jobs.mutation.uses pins {ref!r}; this test documents {PINNED_SHA!r} — "
-        "bump this test together with the workflow"
+    assert USES_RE.match(uses), (
+        f"jobs.mutation.uses must reference mutation-cargo.yml pinned to a "
+        f"full 40-character lowercase hex commit SHA (not a branch or tag), "
+        f"got {uses!r}"
     )
 
 


### PR DESCRIPTION
## Summary

The mutation-testing workflow contract test pinned the exact
`leynos/shared-actions` commit SHA the caller references, so every
Dependabot bump of that reusable-workflow `uses:` ref failed CI until a
maintainer hand-edited the `PINNED_SHA` constant. This hands ownership of
the SHA value to Dependabot while keeping the structural contract intact:
the test now asserts the *shape* of the pin rather than a specific value.

## Review walkthrough

- `tests/workflow_contracts/mutation_testing_test.py`
  - Replace the `PINNED_SHA` / `EXPECTED_USES` constants and the
    exact-equality assertion with a single `USES_RE` regex that requires
    the `uses:` ref to name
    `leynos/shared-actions/.github/workflows/mutation-cargo.yml` pinned to
    a full 40-hex lowercase commit SHA (not a branch or tag).
  - The test no longer asserts *which* SHA is pinned, so a routine
    Dependabot bump no longer fails CI.
  - The module docstring is updated to describe the shape contract and
    Dependabot's ownership of the SHA.
  - All other assertions (permissions, triggers, concurrency, `with:`
    inputs) are unchanged.
- `docs/developers-guide.md`
  - Add a "Workflow pins and Dependabot" subsection documenting the
    policy: verify the caller's shape (correct reusable-workflow path, a
    full 40-char commit SHA, expected triggers/permissions/inputs) but
    never the specific SHA value.

The Rust `tests/workflows.rs` contract test was inspected and needs no
change: it covers `coverage-main.yml` and `dependabot-automerge.yml`
structural contracts and contains no shared-actions SHA assertion or
"all refs identical" consistency check.

`.github/dependabot.yml` already carries a `github-actions` ecosystem
entry with `directory: "/"` (weekly), so nothing there needed changing.

## Validation

- `make test-workflow-contracts` passes (6 passed).
- Verified the regex matches the currently-pinned SHA and a hypothetical
  different 40-hex SHA, and rejects a branch ref such as `@main`.