### PR TITLE
Add the CodeScene mode: check coverage gate to the PR job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,13 +63,12 @@ jobs:
           format: lcov
           use-cargo-nextest: 'false'
           with-ratchet: 'true'
-      # The `mode: check` step is deliberately not wired in yet: CodeScene
-      # project 70676 has no coverage-gates configuration, so
-      # `cs-coverage check` fails every run with "HTTP call succeeded,
-      # but the received project-config isn't valid. Lacks the gates
-      # configuration." — a CodeScene-side per-project setting, not a CI
-      # defect (ddlint and chutoro projects hit the byte-identical error;
-      # see ddlint#287). Add the check step in a fast-follow PR once
-      # coverage-main.yml has uploaded to main at least once and the gate
-      # is confirmed to resolve, or once CodeScene confirms the project's
-      # coverage gate is enabled.
+      - name: Check coverage against CodeScene gates
+        if: env.CS_ACCESS_TOKEN != '' && github.event_name == 'pull_request'
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@29eea2635ee0f92e42c05f4cd360b7f1a2f00b12
+        with:
+          format: lcov
+          mode: check
+          project-url: https://api.codescene.io/v2/projects/70676
+          access-token: ${{ env.CS_ACCESS_TOKEN }}
+          installer-checksum: ${{ env.CODESCENE_CLI_SHA256 }}


### PR DESCRIPTION
## Summary

- Wire the deferred `mode: check` CodeScene coverage gate into the PR
  build-test job, replacing the placeholder comment left when the
  upload-only wiring landed (#72). Project 70676's coverage-gate
  configuration is now populated, so `cs-coverage check` can run.
- Reuse the `upload-codescene-coverage` pin already used by
  `coverage-main.yml` (`29eea2635ee0f92e42c05f4cd360b7f1a2f00b12`) so
  Dependabot keeps one ownership trail for that action across both
  workflows.

## Review walkthrough

- [`.github/workflows/ci.yml`](https://github.com/leynos/lag-complexity/blob/codescene-mode-check/.github/workflows/ci.yml):
  the new `Check coverage against CodeScene gates` step runs after
  `Generate coverage`, guarded on `CS_ACCESS_TOKEN` being set and the
  event being a `pull_request` (push-to-main coverage stays on
  `mode: upload` in `coverage-main.yml`, untouched here).
- `coverage-main.yml` is unchanged.
- No workflow-contract test in `tests/workflow_contracts/` asserts the
  PR coverage step shape, so none needed updating.

## Validation

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — passes.
- `GET https://api.codescene.io/v2/code-coverage/projects/70676/config`
  returns a populated `gates` array (confirms the gate is no longer
  bare, per the estate rollout's bootstrap-blocker finding).
- CI on this PR's own head is the real test: confirm the `build-test`
  job's `Check coverage against CodeScene gates` step executes (not
  skipped) and succeeds, and that the `CodeScene Code Coverage` check
  completes rather than erroring with "Lacks the gates configuration".
