### PR TITLE
Bump whitaker-installer to 0.2.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
       BUILD_PROFILE: debug
-      WHITAKER_INSTALLER_VERSION: '0.2.6'
+      WHITAKER_INSTALLER_VERSION: '0.2.7'
       CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN || '' }}
       CODESCENE_CLI_SHA256: ${{ vars.CODESCENE_CLI_SHA256 || '' }}
     steps:


### PR DESCRIPTION
This pull request bumps the Whitaker installer pin from 0.2.5 to 0.2.6, because the whitaker Dylint suite's rolling release now pins toolchain `nightly-2026-05-28`, which requires cargo-dylint 6.0.1. Installer 0.2.5 provisions cargo-dylint 4.1.0, whose driver cannot build against that nightly, leaving the CI lint step red. Installer 0.2.6 provisions cargo-dylint 6.0.1 and its prebuilt dependency binaries are now published, so the lint step should go green again.

## Changed files

- [`.github/workflows/ci.yml`](https://github.com/leynos/lag-complexity/blob/bump-whitaker-installer-0.2.6/.github/workflows/ci.yml)
