### PR TITLE
Document mutation-testing workflow contract tests

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -93,3 +93,55 @@ def test_uses_pinned_full_sha(caller_step):
 If a workflow's behaviour genuinely depends on a feature only present from a
 particular commit onwards, express that as a comment or a changelog note, not
 as a test assertion on the SHA string.
+
+## Mutation-testing workflow contract tests
+
+This repository runs scheduled, informational mutation testing through a thin
+caller workflow, [`.github/workflows/mutation-testing.yml`](../.github/workflows/mutation-testing.yml),
+which delegates to the shared reusable workflow
+`leynos/shared-actions/.github/workflows/mutation-cargo.yml`. The heavy
+lifting — running `cargo-mutants`, sharding, and summarizing survivors —
+lives in `shared-actions`; this repository carries only declarative
+configuration. The run is **informational only**: it never gates a pull
+request. Survivors are reported through the job summary and downloadable
+artefacts so they can be triaged into tests, not enforced as a blocking
+check.
+
+The workflow runs in two modes. A **daily schedule** (09:20 UTC) fires a
+change-scoped run that mutates only the source files touched within the
+detection window, so quiet days are cheap no-ops. A **manual dispatch** (the
+Actions "Run workflow" control) mutates the whole crate; select a branch in
+that control to exercise a feature branch.
+
+The caller passes a small set of configuration inputs, each carrying intent:
+
+- `extra-args` — `--all-features`, so the mutation run mirrors the CI test
+  baseline; a mismatch would report feature-gated code as untested.
+- `exclude-globs` — `src/tests/**,tests/support/**,src/bin/bless_traces.rs`,
+  keeping the re-exported test module, test-support helpers, and the
+  manually run golden-snapshot regenerator out of the survivors table, since
+  none of them is guarded by the test suite.
+
+The `uses:` reference pins the shared workflow to a full 40-character commit
+SHA rather than a branch or tag, so a force-push upstream cannot silently
+change what runs here. The contract test asserts only that the pin is a full
+commit SHA, not a particular value, so Dependabot bumps it automatically
+without any accompanying test edit.
+
+Because the caller is configuration rather than code, a contract test in
+`tests/workflow_contracts/mutation_testing_test.py` pins the shape it must
+uphold, failing the pull request when the caller drifts — repointing the pin
+at a branch, widening the token scope, or dropping a configuration input —
+rather than letting the breakage surface only in a scheduled run. Run it
+locally with `make test-workflow-contracts`. The test validates:
+
+- the `uses:` reference targets `mutation-cargo.yml` pinned to a full commit
+  SHA;
+- the `with:` block carries exactly the expected `extra-args` and
+  `exclude-globs` configuration;
+- job permissions are least-privilege (`contents: read`, `id-token: write`)
+  and the workflow-level default token scope is empty;
+- `concurrency` serializes runs per ref without cancelling one in progress;
+  and
+- the triggers keep the daily schedule and a plain `workflow_dispatch` with
+  no legacy branch input.


### PR DESCRIPTION
## Summary

Adds a `## Mutation-testing workflow contract tests` section to
`docs/developers-guide.md`, documenting the thin caller workflow at
`.github/workflows/mutation-testing.yml`, its two run modes (daily
change-scoped schedule and whole-crate manual dispatch), the caller's
`extra-args`/`exclude-globs` inputs, and what
`tests/workflow_contracts/mutation_testing_test.py` pins.

- Permutation: **A — Rust (single crate)**.
- Contract-test style: **shape-only** (`USES_RE` regex asserting a full
  40-hex commit SHA on `mutation-cargo.yml`). The SHA value itself is not
  hard-coded, so Dependabot bumps it without any accompanying test edit.
  There is no `pytestmark`/skip-if guard — this is a Rust repository, so
  the Python sandbox-omits-`.github/` concern from the mutmut permutation
  does not apply here.
- Local run command documented: `make test-workflow-contracts` (the
  Makefile already exposes this target, wrapping
  `uv run --with 'pytest>=8' --with 'pyyaml>=6' pytest tests/workflow_contracts -q`).
- Only the `with:` inputs the caller actually sets are documented
  (`extra-args: "--all-features"` and
  `exclude-globs: "src/tests/**,tests/support/**,src/bin/bless_traces.rs"`);
  there is no `paths` or `extra-crate-dirs` input in this caller.

## Roadmap/execplan note

`docs/roadmap.md` and `docs/model-training-pipeline-roadmap.md` contain no
mutation-testing or workflow-contract-test tracking items, so no
roadmap/execplan annotation applies.

## TOC

`docs/developers-guide.md` has no table of contents or index list near the
top (it is a flat sequence of `##` sections), so no cross-link entry was
added; the new section was appended after the existing "Workflow pins and
Dependabot" section, which it complements.

## Docs lint

`make markdownlint` passed (spelling check via `make spelling`, then
`markdownlint-cli2` over all tracked Markdown, 0 errors). Two words in the
initial draft (`summarising`, `serialises`) were corrected to the en-GB
Oxford `-ize` forms (`summarizing`, `serializes`) to satisfy the repository's
typos policy. The generated `typos.toml` was regenerated as a side effect of
running `make spelling` but reverted before committing, since that churn is
unrelated to this change.

## Files changed

- [`docs/developers-guide.md`](../../docs/developers-guide.md)
