### PR TITLE
Bump shared-actions pins to 18bed1ca

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
           with-ratchet: 'true'
       - name: Check coverage against CodeScene gates
         if: env.CS_ACCESS_TOKEN != '' && github.event_name == 'pull_request'
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@29eea2635ee0f92e42c05f4cd360b7f1a2f00b12
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         with:
           format: lcov
           mode: check

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -36,7 +36,7 @@ jobs:
           with-ratchet: 'true'
       - name: Upload coverage data to CodeScene
         if: env.CS_ACCESS_TOKEN
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@29eea2635ee0f92e42c05f4cd360b7f1a2f00b12
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         with:
           format: lcov
           access-token: ${{ env.CS_ACCESS_TOKEN }}

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       contents: read
       id-token: write # OIDC workflow-source resolution
-    uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+    uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@18bed1ca49a6de3d8882bd72635a32ae3f023d57
     with:
       extra-args: "--all-features"
       exclude-globs: "src/tests/**,tests/support/**,src/bin/bless_traces.rs"


### PR DESCRIPTION
## Summary
Bumps every `leynos/shared-actions` workflow and action reference to
`18bed1ca49a6de3d8882bd72635a32ae3f023d57` (current upstream main at
the time of the estate sweep).

This picks up the coverage-ratchet fix from shared-actions#353: the
baseline can now advance (cache save-key fix) and a symmetric ±1pp
dead-band absorbs coverage measurement noise. It also carries the
whitaker-installer 0.2.6 bump and the mutation-run workspace
relocation.

## Review walkthrough
Mechanical SHA substitution in `.github/workflows/` only. References
already at or beyond the fix commit are left untouched. Dependabot
retains ownership of future bumps; contract tests assert shape (path @
40-hex SHA), not the value.

## Validation
CI on this pull request exercises the bumped references directly.
