### PR TITLE
Remove the obsolete dylint-link preinstall workaround

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,14 +44,6 @@ jobs:
               cargo install --locked whitaker-installer --version "${WHITAKER_INSTALLER_VERSION}"
             fi
           fi
-          # whitaker-installer 0.2.6 probes binstall with the same broken
-          # `--version` flag, so its dylint-link fallback compiles from
-          # crates.io and needs rustc >= 1.91 — newer than this repository's
-          # pinned nightly. Preinstall the prebuilt dylint-link that the
-          # installer expects so it detects the tool and skips that path.
-          if cargo binstall -V >/dev/null 2>&1; then
-            cargo binstall --no-confirm dylint-link@6.0.1
-          fi
           whitaker-installer
       - name: Lint
         run: make lint


### PR DESCRIPTION
## Summary

This branch removes a CI workaround that is no longer needed now that the Whitaker installer is pinned to `0.2.7`.

The lint step preinstalled `dylint-link@6.0.1` via `cargo binstall` so the installer would detect the tool on `PATH` and skip installing it. That existed because installer 0.2.6 verified `dylint-link` by executing it as a `--help` health check; the probe failed (`dylint-link` is a linker wrapper with no reliable self-reporting subcommand), and verification fell back to a source build of `dylint-link` 6.0.1, which cannot compile on this repository's pinned toolchain. Installer 0.2.7 ([leynos/whitaker#299](https://github.com/leynos/whitaker/issues/299)) trusts the download, checksum, extraction, and permission pipeline instead of executing the wrapper, so it installs `dylint-link` from the verified repository release directly. The preinstall, and its stale 0.2.6 comment, are now dead weight.

## Changes

- Remove the `dylint-link@6.0.1` preinstall block and its comment from the "Install the Whitaker Dylint suite" step in [.github/workflows/ci.yml](https://github.com/leynos/lag-complexity/blob/remove-dylint-link-workaround/.github/workflows/ci.yml).

## Validation

- CI on this PR exercises the lint gate; the installer now provisions `dylint-link` from the repository release without the preinstall, as already proven on the estate under 0.2.7.

## Notes

No Rust toolchain pin is changed and the Whitaker lint gate is not weakened.
